### PR TITLE
L2cap stability improvements

### DIFF
--- a/L2CAP_README.md
+++ b/L2CAP_README.md
@@ -1,25 +1,15 @@
-# L2CAP Implementation - Flutter Blue Plus
+# L2CAP Implementation - flutter_blue_max
 
-Flutter Blue Plus provides comprehensive L2CAP (Logical Link Control and Adaptation Protocol) support with full cross-platform compatibility and object-oriented design that seamlessly integrates with the library's existing architecture.
+flutter_blue_max provides L2CAP CoC (Connection-oriented Channel) support on iOS and Android, with an object-oriented design that follows the library's existing architecture.
 
 ## Features
 
-- ✅ **Full Cross-Platform Support**: iOS client connections, Android client/server operations
-- ✅ **Object-Oriented Design**: Dedicated `BluetoothL2capChannel` objects for clean API
-- ✅ **Complete Server Management**: Start/stop L2CAP servers with PSM-specific control
-- ✅ **Comprehensive Event Handling**: 5 different event types for complete lifecycle tracking
-- ✅ **Secure & Insecure Channels**: Support for both secure and insecure L2CAP connections
-- ✅ **Auto PSM Assignment**: Automatic PSM assignment for server operations
-- ✅ **Stream-Based Data Handling**: Efficient data transfer with stream management
-
-## Architecture Overview
-
-L2CAP follows the same object-oriented patterns as all other Flutter Blue Plus functionality:
-
-1. **Device Operations** → Return dedicated objects
-2. **Object Encapsulation** → Operations belong to objects, not devices  
-3. **Parameter Elimination** → No repetitive parameter passing
-4. **Consistent Error Handling** → Same exception patterns as characteristics/services
+- ✅ **Client & Server on both platforms**: open channels to a remote PSM, or publish your own
+- ✅ **Object-Oriented Design**: dedicated `BluetoothL2capChannel` objects for a clean API
+- ✅ **Full Lifecycle Events**: connected, data received, and closed events as Dart streams
+- ✅ **Secure & Insecure Channels**: support for both secure and insecure L2CAP connections
+- ✅ **Auto PSM Assignment**: the OS assigns a PSM when starting a server
+- ✅ **Timeout Protection**: open/listen calls time out instead of blocking the package forever
 
 ## Quick Start
 
@@ -32,10 +22,21 @@ import 'package:flutter_blue_max/flutter_blue_max.dart';
 int psm = await FlutterBlueMax.listenL2capChannel(secure: true);
 print('L2CAP server listening on PSM: $psm');
 
+// A client connected: build a channel handle from the event to talk to it
+BluetoothL2capChannel? clientChannel;
+FlutterBlueMax.onL2capConnected.listen((evt) {
+  clientChannel = BluetoothL2capChannel(deviceId: evt.remoteId, psm: evt.psm);
+  clientChannel!.write([0x01, 0x02, 0x03]); // send data back to the client
+});
+
 // Listen for incoming data
 FlutterBlueMax.onL2capReceived.listen((data) {
-  print('Received ${data.bytes.length} bytes from ${data.remoteId}');
-  // Handle incoming data
+  print('Received ${data.value.length} bytes from ${data.remoteId}');
+});
+
+// Notice dead channels (client closed, stream error, disconnect)
+FlutterBlueMax.onL2capClosed.listen((evt) {
+  print('Channel closed: ${evt.remoteId} / PSM ${evt.psm}');
 });
 
 // Stop server when done
@@ -54,8 +55,13 @@ BluetoothL2capChannel channel = await device.openL2CapChannel(1234, secure: true
 // Write data
 await channel.write([0x01, 0x02, 0x03, 0x04]);
 
-// Read data
-List<int> response = await channel.read();
+// Receive data (preferred over polling with read())
+channel.onL2CapChannelReceived.listen((value) {
+  print('Received ${value.length} bytes');
+});
+
+// Notice when the channel dies
+channel.onClosed.first.then((_) => print('Channel closed by remote'));
 
 // Close channel
 await channel.close();
@@ -65,25 +71,25 @@ await channel.close();
 
 ### FlutterBlueMax (Static Methods)
 
-#### `listenL2capChannel({bool secure = true})`
+#### `listenL2capChannel({bool secure = true, int timeout = 15})`
 Starts an L2CAP server listening for incoming connections.
 
 - **Parameters:**
-  - `secure`: Whether to use secure L2CAP channel (default: true)
+  - `secure`: Whether to use a secure L2CAP channel (default: true)
+  - `timeout`: Seconds to wait for the server to start (default: 15)
 - **Returns:** `Future<int>` - The assigned PSM
-- **Platform:** iOS 11.0+, Android
+- **Platform:** iOS 11.0+, Android 10+ (API 29)
 
 ```dart
 int psm = await FlutterBlueMax.listenL2capChannel(secure: true);
 ```
 
 #### `stopL2capServer(int psm)`
-Stops an L2CAP server by PSM.
+Stops an L2CAP server by PSM and closes its accepted channels.
 
 - **Parameters:**
   - `psm`: The PSM of the server to stop
 - **Returns:** `Future<void>`
-- **Platform:** iOS 11.0+, Android
 
 ```dart
 await FlutterBlueMax.stopL2capServer(psm);
@@ -91,15 +97,18 @@ await FlutterBlueMax.stopL2capServer(psm);
 
 ### BluetoothDevice
 
-#### `openL2CapChannel(int psm, {bool secure = true})`
+#### `openL2CapChannel(int psm, {bool secure = true, int timeout = 35})`
 Opens an L2CAP channel to the connected device.
 
 - **Parameters:**
   - `psm`: Protocol Service Multiplexer to connect to
-  - `secure`: Whether to use secure L2CAP channel (default: true)
+  - `secure`: Whether to use a secure L2CAP channel (default: true).
+    On Android this selects `createL2capChannel()` vs `createInsecureL2capChannel()`;
+    on iOS security is controlled by the server's encryption setting.
+  - `timeout`: Seconds to wait for the channel to open (default: 35)
 - **Returns:** `Future<BluetoothL2capChannel>`
-- **Throws:** `FlutterBlueMaxException` if device not connected
-- **Platform:** iOS 11.0+, Android
+- **Throws:** `FlutterBlueMaxException` if the device is not connected, the open fails, or the timeout elapses
+- **Platform:** iOS 11.0+, Android 10+ (API 29)
 
 ```dart
 BluetoothL2capChannel channel = await device.openL2CapChannel(1234, secure: true);
@@ -107,7 +116,8 @@ BluetoothL2capChannel channel = await device.openL2CapChannel(1234, secure: true
 
 ### BluetoothL2capChannel
 
-The `BluetoothL2capChannel` class encapsulates an L2CAP channel connection and provides methods for data transfer.
+Encapsulates one L2CAP channel. Returned by `openL2CapChannel()`, or constructed
+from an `onL2capConnected` event for server-accepted channels.
 
 #### Properties
 - `DeviceIdentifier deviceId` - The device this channel connects to
@@ -116,66 +126,90 @@ The `BluetoothL2capChannel` class encapsulates an L2CAP channel connection and p
 #### `write(List<int> data)`
 Writes data to the L2CAP channel.
 
-- **Parameters:**
-  - `data`: List of bytes to write
-- **Returns:** `Future<void>`
-- **Throws:** `FlutterBlueMaxException` on write failure
+- **Returns:** `Future<void>` - completes once the platform has accepted all bytes
+- **Throws:** `FlutterBlueMaxException` on write failure or if the channel is closed
 
 ```dart
 await channel.write([0x48, 0x65, 0x6C, 0x6C, 0x6F]); // "Hello"
 ```
 
 #### `read()`
-Reads available data from the L2CAP channel.
+Reads data currently buffered for this channel. Returns an empty list when no
+data is buffered — it does not wait for data to arrive. Prefer the event
+streams for reception.
 
-- **Returns:** `Future<List<int>>` - The received bytes
-- **Throws:** `FlutterBlueMaxException` if channel not found
+- **Returns:** `Future<List<int>>` - The received bytes (possibly empty)
 
 ```dart
 List<int> data = await channel.read();
-String message = String.fromCharCodes(data);
 ```
 
 #### `close()`
-Closes the L2CAP channel and releases resources.
-
-- **Returns:** `Future<void>`
+Closes the L2CAP channel and releases resources. Does not emit an `onClosed` event.
 
 ```dart
 await channel.close();
 ```
 
+#### `onL2CapChannelReceived`
+Stream of incoming data for this channel only (`Stream<List<int>>`).
+
+#### `onClosed`
+Stream that emits when this channel dies — remote close, stream error, or
+device disconnect (`Stream<void>`). Not emitted for a local `close()` call; a
+single close may be reported more than once in rare races, so cancel the
+subscription on the first event if you only care about the transition.
+
 ## Event Streams
 
-Flutter Blue Plus provides comprehensive event streams for L2CAP operations:
+Global streams on `FlutterBlueMax` (all devices, all PSMs). Match events to
+your channels by **device + PSM**, not PSM alone — multiple devices commonly
+share the same PSM.
+
+### `FlutterBlueMax.onL2capConnected`
+A remote device connected to a server started with `listenL2capChannel`.
+Build a `BluetoothL2capChannel` from the event to talk to the client.
+
+The event's `remoteId` is the client's MAC address on Android; on iOS
+CoreBluetooth does not expose the connecting central, so the placeholder id
+`server` is reported instead. Both platforms accept either id for operations
+on server-accepted channels, but data and close events always carry the same
+id as this event — so always key channels by the id reported here.
+
+```dart
+FlutterBlueMax.onL2capConnected.listen((L2CapChannelConnected evt) {
+  final channel = BluetoothL2capChannel(deviceId: evt.remoteId, psm: evt.psm);
+});
+```
 
 ### `FlutterBlueMax.onL2capReceived`
-Stream of incoming L2CAP data.
+Incoming L2CAP data, for client and server-accepted channels.
 
 ```dart
 FlutterBlueMax.onL2capReceived.listen((L2CapChannelData data) {
   print('Device: ${data.remoteId}');
-  print('PSM: ${data.psm}');  
-  print('Data: ${data.bytes}');
+  print('PSM: ${data.psm}');
+  print('Data: ${data.value}');
 });
 ```
 
-### Platform Events (iOS/Darwin)
-Additional events available on iOS platform:
+### `FlutterBlueMax.onL2capClosed`
+A channel died: the remote closed it, a stream error occurred, or the device
+disconnected. Not emitted for a local `close()` call.
 
-- `OnL2CapChannelOpened` - Channel connection established
-- `OnL2CapChannelClosed` - Channel connection closed
-- `OnL2CapChannelPublished` - Server started listening
-- `OnL2CapChannelUnpublished` - Server stopped listening
-- `OnL2CapChannelReceived` - Data received on channel
+```dart
+FlutterBlueMax.onL2capClosed.listen((L2CapChannelClosed evt) {
+  print('Closed: ${evt.remoteId} / PSM ${evt.psm}');
+});
+```
 
 ## Platform Support
 
 | Platform | Client Support | Server Support | Minimum Version |
-|----------|----------------|----------------|-----------------|
-| **iOS**     | ✅ Full        | ✅ Full        | iOS 11.0       |
-| **Android** | ✅ Full        | ✅ Full        | Android API 21  |
-| **Web**     | ❌ Not supported | ❌ Not supported | N/A           |
+|----------|----------------|----------------|------------------|
+| **iOS**     | ✅ Full        | ✅ Full        | iOS 11.0         |
+| **Android** | ✅ Full        | ✅ Full        | Android 10 (API 29) |
+| **Web**     | ❌ Not supported | ❌ Not supported | N/A            |
 
 ## Complete Example
 
@@ -184,17 +218,32 @@ import 'package:flutter_blue_max/flutter_blue_max.dart';
 
 class L2CAPExample {
   int? serverPsm;
+  BluetoothL2capChannel? serverChannel; // channel to a connected client
   BluetoothL2capChannel? clientChannel;
 
   // Start L2CAP server
   Future<void> startServer() async {
     serverPsm = await FlutterBlueMax.listenL2capChannel(secure: true);
     print('L2CAP server started on PSM: $serverPsm');
-    
-    // Listen for incoming data
+
+    FlutterBlueMax.onL2capConnected.listen((evt) {
+      if (evt.psm != serverPsm) return;
+      serverChannel = BluetoothL2capChannel(deviceId: evt.remoteId, psm: evt.psm);
+      print('Client connected: ${evt.remoteId}');
+    });
+
     FlutterBlueMax.onL2capReceived.listen((data) {
-      print('Server received: ${String.fromCharCodes(data.bytes)}');
-      print('From device: ${data.remoteId}, PSM: ${data.psm}');
+      if (data.psm != serverPsm) return;
+      print('Server received: ${String.fromCharCodes(data.value)}');
+    });
+
+    FlutterBlueMax.onL2capClosed.listen((evt) {
+      if (serverChannel != null &&
+          evt.remoteId == serverChannel!.deviceId &&
+          evt.psm == serverChannel!.psm) {
+        print('Client channel closed');
+        serverChannel = null;
+      }
     });
   }
 
@@ -207,18 +256,19 @@ class L2CAPExample {
 
     // Open L2CAP channel
     clientChannel = await device.openL2CapChannel(serverPsm!, secure: true);
-    
+
+    // React to incoming data and channel death
+    clientChannel!.onL2CapChannelReceived.listen((value) {
+      print('Client received: ${String.fromCharCodes(value)}');
+    });
+    clientChannel!.onClosed.first.then((_) {
+      print('Channel closed by remote');
+      clientChannel = null;
+    });
+
     // Send data
     String message = "Hello from L2CAP client!";
     await clientChannel!.write(message.codeUnits);
-    
-    // Read response (if expected)
-    try {
-      List<int> response = await clientChannel!.read();
-      print('Client received: ${String.fromCharCodes(response)}');
-    } catch (e) {
-      print('No immediate response: $e');
-    }
   }
 
   // Cleanup
@@ -228,11 +278,12 @@ class L2CAPExample {
       await clientChannel!.close();
       clientChannel = null;
     }
-    
+
     // Stop server
     if (serverPsm != null) {
       await FlutterBlueMax.stopL2capServer(serverPsm!);
       serverPsm = null;
+      serverChannel = null;
     }
   }
 }
@@ -240,7 +291,7 @@ class L2CAPExample {
 
 ## Error Handling
 
-L2CAP methods follow the same error handling patterns as other Flutter Blue Plus operations:
+L2CAP methods follow the same error handling patterns as other flutter_blue_max operations. `openL2CapChannel` and `listenL2capChannel` also throw when their timeout elapses, so a hung platform call cannot block the package-wide operation mutexes forever.
 
 ```dart
 try {
@@ -264,16 +315,16 @@ try {
 ## Best Practices
 
 1. **Always check device connection** before opening L2CAP channels
-2. **Close channels explicitly** to free resources
-3. **Stop servers when done** to prevent resource leaks  
-4. **Handle platform limitations** (check for web/unsupported platforms)
-5. **Use secure channels** unless specifically needing insecure connections
-6. **Implement proper error handling** for connection failures
-7. **Listen to event streams** for incoming data and connection state changes
+2. **Listen to `onClosed` / `onL2capClosed`** — otherwise the only sign of a dead channel is a failing write
+3. **Match events by device + PSM**, not PSM alone; key server channels by the id from `onL2capConnected`
+4. **Close channels explicitly** to free resources
+5. **Stop servers when done** to prevent resource leaks
+6. **Prefer the event streams over `read()`** — `read()` only returns already-buffered data
+7. **Use secure channels** unless specifically needing insecure connections
 
 ## Architecture Alignment
 
-L2CAP implementation follows the exact same patterns as Flutter Blue Plus characteristics and services:
+L2CAP implementation follows the exact same patterns as flutter_blue_max characteristics and services:
 
 - **Object Creation**: `device.openL2CapChannel()` → returns channel object (like `device.discoverServices()`)
 - **Object Operations**: `channel.read()`, `channel.write()` (like `characteristic.read()`)
@@ -281,4 +332,4 @@ L2CAP implementation follows the exact same patterns as Flutter Blue Plus charac
 - **Error Handling**: Same exception types and patterns
 - **Platform Abstraction**: Same underlying platform interface
 
-This ensures L2CAP feels natural and familiar to existing Flutter Blue Plus developers.
+This ensures L2CAP feels natural and familiar to existing flutter_blue_max developers.

--- a/packages/flutter_blue_max/example/lib/widgets/l2cap_section.dart
+++ b/packages/flutter_blue_max/example/lib/widgets/l2cap_section.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -28,10 +29,16 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
   final TextEditingController _psmController = TextEditingController();
   final TextEditingController _l2capDataController = TextEditingController();
   final List<String> _l2capReceivedList = [];
+  int _rxBytesTotal = 0;
   StreamSubscription<L2CapChannelData>? _l2capSubscription;
+  StreamSubscription<L2CapChannelConnected>? _l2capConnectedSubscription;
+  StreamSubscription<L2CapChannelClosed>? _l2capClosedSubscription;
   bool _l2capSecure = false;
   bool _isServerMode = true;
   bool _hasValidPsm = false;
+
+  static const int _maxLogEntries = 300;
+  static const int _maxDataEntries = 200;
 
   void _onPsmControllerChanged() {
     {
@@ -55,12 +62,39 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
   void _log(String message) {
     final ts = DateTime.now().toIso8601String();
     _logMessages.insert(0, '[$ts] $message');
-    if (_logMessages.length > 500) {
-      _logMessages.removeRange(500, _logMessages.length);
+    if (_logMessages.length > _maxLogEntries) {
+      _logMessages.removeRange(_maxLogEntries, _logMessages.length);
     }
     if (mounted && _tabController.index == 1) {
       setState(() {});
     }
+  }
+
+  void _addReceivedEntry(String entry) {
+    _l2capReceivedList.insert(0, entry);
+    if (_l2capReceivedList.length > _maxDataEntries) {
+      _l2capReceivedList.removeRange(_maxDataEntries, _l2capReceivedList.length);
+    }
+  }
+
+  // Show text payloads as text, binary payloads as a length + hex preview
+  String _formatBytes(List<int> value) {
+    if (value.isEmpty) {
+      return '0 bytes';
+    }
+    final bool printable =
+        value.every((b) => b == 0x09 || b == 0x0a || b == 0x0d || (b >= 0x20 && b <= 0x7e));
+    if (printable) {
+      return utf8.decode(value, allowMalformed: true);
+    }
+    final hex = value.take(16).map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ');
+    return '${value.length} bytes: $hex${value.length > 16 ? ' …' : ''}';
+  }
+
+  /// The channel addressed by the PSM text field, or null if none is open.
+  BluetoothL2capChannel? _channelForPsmField() {
+    final int? psm = int.tryParse(_psmController.text);
+    return psm != null ? _activeL2CapChannels[psm] : null;
   }
 
   @override
@@ -87,30 +121,52 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
     // Subscribe to FBP logs for the Logs view
     _logsSubscription = FlutterBlueMax.logs.listen((line) {
       _logMessages.insert(0, line);
-      if (_logMessages.length > 300) {
-        _logMessages.removeRange(300, _logMessages.length);
+      if (_logMessages.length > _maxLogEntries) {
+        _logMessages.removeRange(_maxLogEntries, _logMessages.length);
       }
       if (mounted && _tabController.index == 1) {
         setState(() {});
       }
     });
 
-    // Subscribe to L2CAP received data stream
+    // Subscribe to L2CAP received data, scoped to the channels this screen
+    // opened or accepted (matched by device + PSM, not PSM alone)
     _l2capSubscription = FlutterBlueMax.onL2capReceived.listen((evt) {
-      // Route only events for active channels or server placeholder
-      final bool isServerEvent = evt.remoteId.str == 'server';
-      final bool isClientEvent = _activeL2CapChannels.containsKey(evt.psm);
-      if (!isServerEvent && !isClientEvent) return;
+      final channel = _activeL2CapChannels[evt.psm];
+      if (channel == null || channel.deviceId != evt.remoteId) return;
 
-      final receivedData = String.fromCharCodes(evt.value);
+      _rxBytesTotal += evt.value.length;
+      final receivedData = _formatBytes(evt.value);
       _log('L2CAP RX psm=${evt.psm} remote=${evt.remoteId.str} bytes=${evt.value.length} data="$receivedData"');
-      _l2capReceivedList.insert(0, receivedData);
-      if (_l2capReceivedList.length > 200) {
-        _l2capReceivedList.removeRange(200, _l2capReceivedList.length);
-      }
+      _addReceivedEntry(receivedData);
       if (mounted && _tabController.index == 0) {
         setState(() {});
       }
+    });
+
+    // A client connected to our L2CAP server: track the accepted channel so
+    // Send/Read target it. The event's remoteId is the client's MAC address
+    // on Android and the placeholder 'server' on iOS.
+    _l2capConnectedSubscription = FlutterBlueMax.onL2capConnected.listen((evt) {
+      if (!_isListeningL2Cap || evt.psm != _listeningPsm) return;
+      _log('Server: client connected remote=${evt.remoteId.str} psm=${evt.psm}');
+      if (!mounted) return;
+      setState(() {
+        _activeL2CapChannels[evt.psm] = BluetoothL2capChannel(deviceId: evt.remoteId, psm: evt.psm);
+      });
+    });
+
+    // The remote closed a channel (or it died from a stream error/disconnect):
+    // drop it from the UI instead of finding out on the next failed write
+    _l2capClosedSubscription = FlutterBlueMax.onL2capClosed.listen((evt) {
+      final channel = _activeL2CapChannels[evt.psm];
+      if (channel == null || channel.deviceId != evt.remoteId) return;
+      _log('Channel closed by remote remote=${evt.remoteId.str} psm=${evt.psm}');
+      Snackbar.show(ABC.c, "L2CAP channel closed - PSM: ${evt.psm}", success: false);
+      if (!mounted) return;
+      setState(() {
+        _activeL2CapChannels.remove(evt.psm);
+      });
     });
   }
 
@@ -122,16 +178,19 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
     _l2capDataController.dispose();
     _logsSubscription?.cancel();
     _l2capSubscription?.cancel();
+    _l2capConnectedSubscription?.cancel();
+    _l2capClosedSubscription?.cancel();
     _tabController.dispose();
     super.dispose();
   }
 
   // L2CAP Methods
   Future<void> resetL2cap({bool keepServerListening = true, bool clearLogs = false}) async {
-    // Close all client-side channels (keep server placeholder if requested)
-    final channelsToClose = _activeL2CapChannels.entries
-        .where((e) => e.value.deviceId.str != 'server')
-        .map((e) => e.value)
+    // Close the client channels opened to this screen's device. Server-accepted
+    // channels are left alone — their lifecycle is driven by the
+    // onL2capConnected / onL2capClosed events and by stopping the server.
+    final channelsToClose = _activeL2CapChannels.values
+        .where((ch) => ch.deviceId == widget.device.remoteId)
         .toList(growable: false);
 
     for (final ch in channelsToClose) {
@@ -155,26 +214,19 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
     setState(() {
       _l2capDataController.clear();
       _l2capReceivedList.clear();
+      _rxBytesTotal = 0;
       if (clearLogs) _logMessages.clear();
 
-      final bool keepServer = keepServerListening && _isListeningL2Cap && _listeningPsm != null;
-
-      // Reset channel map
-      _activeL2CapChannels.removeWhere((psm, ch) => ch.deviceId.str != 'server');
-      if (keepServer) {
-        // Ensure server placeholder exists
-        _activeL2CapChannels[_listeningPsm!] = BluetoothL2capChannel(
-          deviceId: DeviceIdentifier('server'),
-          psm: _listeningPsm!,
-        );
-      } else {
+      for (final ch in channelsToClose) {
+        _activeL2CapChannels.remove(ch.psm);
+      }
+      if (!keepServerListening) {
         _activeL2CapChannels.clear();
         _isListeningL2Cap = false;
         _listeningPsm = null;
       }
 
-      // Reset PSM input (no placeholder for demo)
-      _psmController.text = keepServer && _listeningPsm != null ? _listeningPsm!.toString() : '';
+      _psmController.text = _listeningPsm?.toString() ?? '';
     });
   }
 
@@ -190,14 +242,9 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
       setState(() {
         _isListeningL2Cap = true;
         _listeningPsm = psm;
-        // Update the PSM text field with the actual assigned PSM
+        // Update the PSM text field with the actual assigned PSM.
+        // The accepted channel is added once onL2capConnected fires.
         _psmController.text = psm.toString();
-        // Create a server-side channel placeholder so Read/Write work on the server
-        // We use a special remoteId 'server' that the native layer recognizes
-        _activeL2CapChannels[psm] = BluetoothL2capChannel(
-          deviceId: DeviceIdentifier('server'),
-          psm: psm,
-        );
       });
 
       Snackbar.show(ABC.c, "L2CAP Server started on PSM: $_listeningPsm", success: true);
@@ -293,19 +340,16 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
   }
 
   Future onDisconnectL2CapPressed() async {
-    int psm = int.tryParse(_psmController.text) ?? 1001;
-
-    if (!_activeL2CapChannels.containsKey(psm)) {
-      Snackbar.show(ABC.c, "No L2CAP channel open for PSM: $psm", success: false);
+    final channel = _channelForPsmField();
+    if (channel == null) {
+      Snackbar.show(ABC.c, "No L2CAP channel open for PSM: ${_psmController.text}", success: false);
       return;
     }
+    final int psm = channel.psm;
 
     try {
-      var channel = _activeL2CapChannels[psm];
-      if (channel != null) {
-        _log('Closing client channel psm=$psm');
-        await channel.close();
-      }
+      _log('Closing client channel psm=$psm');
+      await channel.close();
 
       setState(() {
         _activeL2CapChannels.remove(psm);
@@ -324,7 +368,6 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
   }
 
   Future onWriteL2CapPressed() async {
-    int psm = int.tryParse(_psmController.text) ?? 1001;
     String data = _l2capDataController.text;
 
     if (data.isEmpty) {
@@ -332,24 +375,20 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
       return;
     }
 
-    if (!_activeL2CapChannels.containsKey(psm)) {
-      Snackbar.show(ABC.c, "No L2CAP channel open for PSM: $psm", success: false);
+    final channel = _channelForPsmField();
+    if (channel == null) {
+      Snackbar.show(ABC.c, "No L2CAP channel open for PSM: ${_psmController.text}", success: false);
       return;
     }
+    final int psm = channel.psm;
 
     try {
-      List<int> bytes = data.codeUnits;
-      var channel = _activeL2CapChannels[psm];
-      if (channel == null) {
-        throw Exception("Channel not found for PSM $psm");
-      }
+      final List<int> bytes = utf8.encode(data);
 
       _log('Write attempt psm=$psm len=${bytes.length}');
       await channel.write(bytes);
 
       Snackbar.show(ABC.c, "L2CAP data sent - ${bytes.length} bytes", success: true);
-      // ignore: avoid_print
-      print("L2CAP Data sent - PSM: $psm, Data: $data, Bytes: ${bytes.length}");
       _l2capDataController.clear();
       _log('Write success psm=$psm len=${bytes.length}');
     } catch (e, backtrace) {
@@ -362,41 +401,81 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
     }
   }
 
-  Future onReadL2CapPressed() async {
-    int psm = int.tryParse(_psmController.text) ?? 1001;
+  // Patterned payload (byte i = i & 0xff) so truncated or corrupted data is
+  // recognizable on the receiving side
+  List<int> _testPayload(int length) => List<int>.generate(length, (i) => i & 0xff);
 
-    if (!_activeL2CapChannels.containsKey(psm)) {
-      Snackbar.show(ABC.c, "No L2CAP channel open for PSM: $psm", success: false);
+  /// Sends one large payload — exercises SDU handling above the MTU size.
+  Future onSendTestPayloadPressed() async {
+    final channel = _channelForPsmField();
+    if (channel == null) {
+      Snackbar.show(ABC.c, "No L2CAP channel open for PSM: ${_psmController.text}", success: false);
+      return;
+    }
+    const int size = 10 * 1024;
+
+    try {
+      _log('Write attempt psm=${channel.psm} len=$size (test payload)');
+      await channel.write(_testPayload(size));
+      Snackbar.show(ABC.c, "L2CAP test payload sent - $size bytes", success: true);
+      _log('Write success psm=${channel.psm} len=$size (test payload)');
+    } catch (e) {
+      Snackbar.show(ABC.c, prettyException("Write L2CAP Channel Error:", e), success: false);
+      _log('Write error psm=${channel.psm} err=$e');
+    }
+  }
+
+  /// Fires many writes without awaiting in between — exercises write
+  /// queueing and backpressure handling.
+  Future onSendBurstPressed() async {
+    final channel = _channelForPsmField();
+    if (channel == null) {
+      Snackbar.show(ABC.c, "No L2CAP channel open for PSM: ${_psmController.text}", success: false);
+      return;
+    }
+    const int count = 20;
+    const int size = 1024;
+
+    _log('Burst write attempt psm=${channel.psm} ${count}x$size bytes');
+    final results = await Future.wait(
+      List.generate(count, (_) {
+        return channel.write(_testPayload(size)).then((_) => true).catchError((e) {
+          _log('Burst write error psm=${channel.psm} err=$e');
+          return false;
+        });
+      }),
+    );
+    final int ok = results.where((r) => r).length;
+    Snackbar.show(ABC.c, "L2CAP burst: $ok/$count writes succeeded", success: ok == count);
+    _log('Burst write done psm=${channel.psm} ok=$ok/$count');
+  }
+
+  Future onReadL2CapPressed() async {
+    final channel = _channelForPsmField();
+    if (channel == null) {
+      Snackbar.show(ABC.c, "No L2CAP channel open for PSM: ${_psmController.text}", success: false);
       return;
     }
 
     try {
-      var channel = _activeL2CapChannels[psm];
-      String receivedData;
-      if (channel != null) {
-        var result = await channel.read();
-        receivedData = String.fromCharCodes(result);
-      } else {
-        // For demo purposes, simulate received data
-        receivedData = "Sample L2CAP data received at ${DateTime.now().toIso8601String()}";
+      final result = await channel.read();
+
+      if (result.isNotEmpty) {
+        setState(() {
+          _addReceivedEntry(_formatBytes(result));
+        });
       }
 
-      setState(() {
-        _l2capReceivedList.insert(0, receivedData);
-        if (_l2capReceivedList.length > 200) {
-          _l2capReceivedList.removeRange(200, _l2capReceivedList.length);
-        }
-      });
-
-      Snackbar.show(ABC.c, "L2CAP data received - ${receivedData.length} chars", success: true);
-      // ignore: avoid_print
-      print("L2CAP Data received - PSM: $psm, Data: $receivedData");
+      Snackbar.show(ABC.c, result.isEmpty ? "L2CAP read - no data available" : "L2CAP read - ${result.length} bytes",
+          success: true);
+      _log('Read psm=${channel.psm} bytes=${result.length}');
     } catch (e, backtrace) {
       Snackbar.show(ABC.c, prettyException("Read L2CAP Channel Error:", e), success: false);
       // ignore: avoid_print
       print(e);
       // ignore: avoid_print
       print("backtrace: $backtrace");
+      _log('Read error psm=${channel.psm} err=$e');
     }
   }
 
@@ -504,7 +583,9 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
               children: [
                 // Data tab
                 Builder(builder: (context) {
-                  final bool canSend = _isServerMode ? _isListeningL2Cap : _activeL2CapChannels.isNotEmpty;
+                  final bool canSend = _isServerMode
+                      ? (_listeningPsm != null && _activeL2CapChannels.containsKey(_listeningPsm))
+                      : _activeL2CapChannels.isNotEmpty;
                   return L2CapListSection(
                     entries: _l2capReceivedList,
                     title: 'Data Transfer',
@@ -513,7 +594,11 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
                         Padding(
                           padding: const EdgeInsets.only(bottom: 8.0),
                           child: Text(
-                            _isServerMode ? 'Start the server to enable sending' : 'Open a channel to enable sending',
+                            _isServerMode
+                                ? (_isListeningL2Cap
+                                    ? 'Waiting for a client to connect…'
+                                    : 'Start the server to enable sending')
+                                : 'Open a channel to enable sending',
                             style: const TextStyle(color: Colors.grey),
                           ),
                         ),
@@ -535,11 +620,37 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
                         maxLines: 1,
                         enabled: true,
                       ),
+                      // Test traffic: one large payload (SDU/MTU handling) and a
+                      // write burst (queueing/backpressure)
+                      Row(
+                        children: [
+                          TextButton.icon(
+                            onPressed: canSend ? onSendTestPayloadPressed : null,
+                            icon: const Icon(Icons.data_usage, size: 16),
+                            label: const Text('Send 10 KB'),
+                          ),
+                          TextButton.icon(
+                            onPressed: canSend ? onSendBurstPressed : null,
+                            icon: const Icon(Icons.bolt, size: 16),
+                            label: const Text('Burst 20×1 KB'),
+                          ),
+                        ],
+                      ),
                     ],
-                    topRightWidget: ElevatedButton.icon(
-                      onPressed: onReadL2CapPressed,
-                      icon: const Icon(Icons.download),
-                      label: const Text('Read Data'),
+                    topRightWidget: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'RX $_rxBytesTotal B',
+                          style: const TextStyle(color: Colors.grey, fontSize: 12),
+                        ),
+                        const SizedBox(width: 8),
+                        ElevatedButton.icon(
+                          onPressed: onReadL2CapPressed,
+                          icon: const Icon(Icons.download),
+                          label: const Text('Read Data'),
+                        ),
+                      ],
                     ),
                   );
                 }),
@@ -598,6 +709,17 @@ class _L2CapSectionState extends State<L2CapSection> with SingleTickerProviderSt
                 'Server listening on PSM: $_listeningPsm (${_l2capSecure ? "Secure" : "Insecure"})',
                 style: TextStyle(color: Colors.green[700], fontWeight: FontWeight.bold),
               ),
+            ),
+          if (_isListeningL2Cap)
+            Padding(
+              padding: const EdgeInsets.only(top: 4.0),
+              child: Builder(builder: (context) {
+                final client = _listeningPsm != null ? _activeL2CapChannels[_listeningPsm] : null;
+                return Text(
+                  client != null ? 'Client connected: ${client.deviceId.str}' : 'Waiting for a client to connect…',
+                  style: TextStyle(color: client != null ? Colors.green[700] : Colors.grey),
+                );
+              }),
             ),
         ],
       ),

--- a/packages/flutter_blue_max/lib/flutter_blue_max.dart
+++ b/packages/flutter_blue_max/lib/flutter_blue_max.dart
@@ -11,7 +11,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_max_platform_interface/flutter_blue_max_platform_interface.dart';
 
 export 'package:flutter_blue_max_platform_interface/flutter_blue_max_platform_interface.dart'
-    show DeviceIdentifier, Guid, LogLevel, PhySupport, L2CapChannelData, L2CapChannelClosed;
+    show DeviceIdentifier, Guid, LogLevel, PhySupport, L2CapChannelData, L2CapChannelClosed, L2CapChannelConnected;
 
 part 'src/bluetooth_characteristic.dart';
 part 'src/bluetooth_descriptor.dart';

--- a/packages/flutter_blue_max/lib/flutter_blue_max.dart
+++ b/packages/flutter_blue_max/lib/flutter_blue_max.dart
@@ -11,7 +11,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_max_platform_interface/flutter_blue_max_platform_interface.dart';
 
 export 'package:flutter_blue_max_platform_interface/flutter_blue_max_platform_interface.dart'
-    show DeviceIdentifier, Guid, LogLevel, PhySupport, L2CapChannelData;
+    show DeviceIdentifier, Guid, LogLevel, PhySupport, L2CapChannelData, L2CapChannelClosed;
 
 part 'src/bluetooth_characteristic.dart';
 part 'src/bluetooth_descriptor.dart';

--- a/packages/flutter_blue_max/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_max/lib/src/bluetooth_device.dart
@@ -709,13 +709,16 @@ class BluetoothDevice {
   /// - [secure] - Whether to use a secure L2CAP channel (default: true)
   ///   - **Android**: Uses `createL2capChannel()` vs `createInsecureL2capChannel()`
   ///   - **iOS**: Security is controlled by the server's `publishL2CAPChannelWithEncryption` setting
+  /// - [timeout] - Seconds to wait for the channel to open (default: 35). Without it,
+  ///   a platform-side open that never completes would hold the package-wide operation
+  ///   mutexes forever and block all further Bluetooth calls.
   ///
   /// **Returns:** A [BluetoothL2capChannel] instance for reading and writing data.
   ///
   /// **Throws:**
   /// - [FlutterBlueMaxException] if the device is not connected
   /// - [FlutterBlueMaxException] if the platform doesn't support L2CAP (e.g., Web)
-  /// - [FlutterBlueMaxException] if the channel cannot be opened
+  /// - [FlutterBlueMaxException] if the channel cannot be opened or the timeout elapses
   ///
   /// **Platform Support:** Android and iOS only (not supported on Web)
   ///
@@ -734,7 +737,7 @@ class BluetoothDevice {
   /// // Always close the channel when done
   /// await channel.close();
   /// ```
-  Future<BluetoothL2capChannel> openL2CapChannel(int psm, {bool secure = true}) async {
+  Future<BluetoothL2capChannel> openL2CapChannel(int psm, {bool secure = true, int timeout = 35}) async {
     // check connected
     if (isDisconnected) {
       throw FlutterBlueMaxException(
@@ -752,13 +755,17 @@ class BluetoothDevice {
     await mtx.take();
 
     try {
-      await FlutterBlueMax._invokeMethod(() => FlutterBlueMaxPlatform.instance.openL2CapChannel(
+      // the timeout is applied inside _invokeMethod so that a platform call that
+      // never completes still releases the "invokeMethod" and "global" mutexes
+      await FlutterBlueMax._invokeMethod(() => FlutterBlueMaxPlatform.instance
+          .openL2CapChannel(
             OpenL2CapChannelRequest(
               remoteId: remoteId.str,
               psm: psm,
               secure: secure,
             ),
-          ));
+          )
+          .fbpTimeout(timeout, "openL2CapChannel"));
 
       return BluetoothL2capChannel(deviceId: remoteId, psm: psm);
     } finally {

--- a/packages/flutter_blue_max/lib/src/bluetooth_l2cap_channel.dart
+++ b/packages/flutter_blue_max/lib/src/bluetooth_l2cap_channel.dart
@@ -135,6 +135,29 @@ class BluetoothL2capChannel {
       .map((d) => d.value);
   }
 
+  /// Stream that emits an event when this channel dies — because the remote
+  /// device closed it, a stream error occurred, or the device disconnected.
+  ///
+  /// Without listening to this stream there is no way to learn that the
+  /// channel is gone other than a failing [write] or [read].
+  ///
+  /// Note: it does not emit for a local [close] call, and a single close may
+  /// be reported more than once in rare cases (e.g. a stream error racing a
+  /// device disconnect) — cancel the subscription on the first event if you
+  /// only care about the transition.
+  ///
+  /// Example:
+  /// ```dart
+  /// channel.onClosed.first.then((_) {
+  ///   print('L2CAP channel closed by remote');
+  /// });
+  /// ```
+  Stream<void> get onClosed {
+    return FlutterBlueMaxPlatform.instance.onL2CapChannelClosed
+      .where((e) => e.remoteId == deviceId && e.psm == psm)
+      .map((e) {});
+  }
+
   @override
   String toString() {
     return 'BluetoothL2capChannel{'

--- a/packages/flutter_blue_max/lib/src/flutter_blue_max.dart
+++ b/packages/flutter_blue_max/lib/src/flutter_blue_max.dart
@@ -134,6 +134,18 @@ class FlutterBlueMax {
   /// covers server-side channels accepted via [listenL2capChannel].
   static Stream<L2CapChannelClosed> get onL2capClosed => FlutterBlueMaxPlatform.instance.onL2CapChannelClosed;
 
+  /// Stream of L2CAP server connection events: emitted when a remote device
+  /// connects to a server started with [listenL2capChannel].
+  ///
+  /// Use the event's remoteId and psm to construct a [BluetoothL2capChannel]
+  /// for talking to the connected client. On Android the remoteId is the
+  /// client's MAC address; on iOS CoreBluetooth does not expose which central
+  /// opened the channel, so the placeholder id `server` is reported instead.
+  /// Both platforms accept either id for operations on server-accepted
+  /// channels, but data and close events always carry the same id as this
+  /// event — so always key channels by the id reported here.
+  static Stream<L2CapChannelConnected> get onL2capConnected => FlutterBlueMaxPlatform.instance.onL2CapChannelConnected;
+
   /// Set configurable options
   ///   - [showPowerAlert] Whether to show the power alert (iOS & MacOS only). i.e. CBCentralManagerOptionShowPowerAlertKey
   ///       To set this option you must call this method before any other method in this package.

--- a/packages/flutter_blue_max/lib/src/flutter_blue_max.dart
+++ b/packages/flutter_blue_max/lib/src/flutter_blue_max.dart
@@ -125,6 +125,15 @@ class FlutterBlueMax {
   /// ```
   static Stream<L2CapChannelData> get onL2capReceived => FlutterBlueMaxPlatform.instance.onL2CapChannelReceived;
 
+  /// Stream of L2CAP channel close events (any device, any PSM).
+  ///
+  /// Emitted when a channel dies — because the remote side closed it, a stream
+  /// error occurred, or the device disconnected — but not for a local
+  /// [BluetoothL2capChannel.close] call. For client channels prefer the
+  /// per-channel [BluetoothL2capChannel.onClosed]; this global stream also
+  /// covers server-side channels accepted via [listenL2capChannel].
+  static Stream<L2CapChannelClosed> get onL2capClosed => FlutterBlueMaxPlatform.instance.onL2CapChannelClosed;
+
   /// Set configurable options
   ///   - [showPowerAlert] Whether to show the power alert (iOS & MacOS only). i.e. CBCentralManagerOptionShowPowerAlertKey
   ///       To set this option you must call this method before any other method in this package.

--- a/packages/flutter_blue_max/lib/src/flutter_blue_max.dart
+++ b/packages/flutter_blue_max/lib/src/flutter_blue_max.dart
@@ -452,6 +452,9 @@ class FlutterBlueMax {
   /// - [secure] - Whether to use a secure L2CAP server (default: true)
   ///   - **Android**: Uses `listenUsingL2capChannel()` vs `listenUsingInsecureL2capChannel()`
   ///   - **iOS**: Uses `publishL2CAPChannelWithEncryption(secure)`
+  /// - [timeout] - Seconds to wait for the server to start (default: 15). Without it,
+  ///   a platform-side listen that never completes would hold the package-wide
+  ///   operation mutex forever and block all further Bluetooth calls.
   ///
   /// **Returns:** The PSM value assigned to this server. Share this value with
   /// remote devices so they can connect to your server.
@@ -479,16 +482,20 @@ class FlutterBlueMax {
   /// // Remember to stop the server when done
   /// await FlutterBlueMax.stopL2capServer(serverPsm);
   /// ```
-  static Future<int> listenL2capChannel({bool secure = true}) async {
+  static Future<int> listenL2capChannel({bool secure = true, int timeout = 15}) async {
     // check platform support
     if (kIsWeb) {
       throw FlutterBlueMaxException(
           ErrorPlatform.fbp, "listenL2capChannel", FbpErrorCode.applePlatformOnly.index, "not supported on web");
     }
 
-    return await _invokeMethod(() => FlutterBlueMaxPlatform.instance.listenL2CapChannel(
+    // the timeout is applied inside _invokeMethod so that a platform call that
+    // never completes still releases the "invokeMethod" mutex
+    return await _invokeMethod(() => FlutterBlueMaxPlatform.instance
+        .listenL2CapChannel(
           ListenL2CapChannelRequest(secure: secure),
-        ));
+        )
+        .fbpTimeout(timeout, "listenL2capChannel"));
   }
 
   /// Stops the L2CAP server listening on the specified PSM.

--- a/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
+++ b/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
@@ -3785,7 +3785,9 @@ class ServerSocketInfo implements L2CapInfo {
     private final L2CapChannelManager.DataReceived dataReceivedCallback;
     private final L2CapChannelManager.ChannelClosed channelClosedCallback;
     private final FlutterBlueMaxPlugin plugin;
-    private boolean isAcceptingConnections;
+    // volatile: written on the main thread (closeSocket), read on the accept
+    // thread — without it the accept loop may never observe the shutdown
+    private volatile boolean isAcceptingConnections;
 
     public ServerSocketInfo(BluetoothServerSocket serverSocket, final L2CapChannelManager.DeviceConnected deviceConnectedCallback, final L2CapChannelManager.DataReceived dataReceivedCallback, final L2CapChannelManager.ChannelClosed channelClosedCallback, final FlutterBlueMaxPlugin plugin) {
         this.serverSocket = serverSocket;
@@ -3813,9 +3815,14 @@ class ServerSocketInfo implements L2CapInfo {
 
     @Override
     public L2CapServerChannel getL2CapChannel(final BluetoothDevice remoteDevice) {
-        for (L2CapServerChannel openChannel : openChannels) {
-            if (remoteDevice.getAddress().equals(openChannel.getSocket().getRemoteDevice().getAddress())) {
-                return openChannel;
+        // iterating a synchronizedList is not atomic and the accept thread
+        // adds connections concurrently — synchronize manually
+        synchronized (openChannels) {
+            for (L2CapServerChannel openChannel : openChannels) {
+                final BluetoothSocket socket = openChannel.getSocket();
+                if (socket != null && remoteDevice.getAddress().equals(socket.getRemoteDevice().getAddress())) {
+                    return openChannel;
+                }
             }
         }
         return null;
@@ -3850,19 +3857,26 @@ class ServerSocketInfo implements L2CapInfo {
                     deviceConnectedCallback.deviceConnected(socket.getRemoteDevice(), getPsm());
                 } catch (IOException e) {
                     if (isAcceptingConnections) {
-                        Log.e(TAG, "Accepting incoming connection failed.", e);
+                        Log.e(TAG, "Accepting incoming connection failed. Stop accepting.", e);
+                        isAcceptingConnections = false;
                     }
+                    // a server socket whose accept() throws is dead (closed or
+                    // adapter off) — retrying would busy-spin on the same error
+                    break;
                 }
             }
         }).start();
     }
 
     public void closeSocket() {
-        for (L2CapServerChannel openChannel : openChannels) {
-            openChannel.close();
+        isAcceptingConnections = false;
+        synchronized (openChannels) {
+            for (L2CapServerChannel openChannel : openChannels) {
+                openChannel.close();
+            }
+            openChannels.clear();
         }
         try {
-            isAcceptingConnections = false;
             serverSocket.close();
         } catch (IOException e) {
             Log.e(TAG, "Closing server socket failed.", e);

--- a/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
+++ b/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
@@ -3410,10 +3410,8 @@ class L2CapChannelManager {
 
 abstract class L2CapChannel {
 
-    // TODO: Find root cause of why 50 bytes is insufficient and implement a more graceful solution
-    // (e.g., dynamic buffer sizing or configurable buffer size). This is a quick fix to make L2CAP work.
-    protected static final int DEFAULT_READ_BUFFER_SIZE = 512;
-    protected final byte[] readBuffer;
+    // Fallback in case the socket cannot report its local MTU.
+    protected static final int FALLBACK_READ_BUFFER_SIZE = 512;
     protected final FlutterBlueMaxPlugin plugin;
     protected BluetoothSocket socket;
     protected OutputStream outputStream;
@@ -3424,9 +3422,17 @@ abstract class L2CapChannel {
     // so a reconnect can never end up with two threads competing for the stream.
     private final AtomicInteger readerGeneration = new AtomicInteger(0);
 
-    public L2CapChannel(final int readBufferSize, final FlutterBlueMaxPlugin plugin) {
-        readBuffer = new byte[readBufferSize];
+    public L2CapChannel(final FlutterBlueMaxPlugin plugin) {
         this.plugin = plugin;
+    }
+
+    // L2CAP CoC sockets are packet-oriented: a read with a buffer smaller than
+    // the incoming SDU silently discards the rest of the packet. Size read
+    // buffers from the socket's local MTU so no SDU can ever be truncated.
+    @TargetApi(Build.VERSION_CODES.Q)
+    protected static int readBufferSize(final BluetoothSocket socket) {
+        final int mtu = socket != null ? socket.getMaxReceivePacketSize() : 0;
+        return Math.max(mtu, FALLBACK_READ_BUFFER_SIZE);
     }
 
     public BluetoothSocket getSocket() {
@@ -3447,8 +3453,7 @@ abstract class L2CapChannel {
         final BluetoothDevice remoteDevice = socket.getRemoteDevice();
         final int generation = readerGeneration.incrementAndGet();
         new Thread(() -> {
-            // private buffer: the shared readBuffer is also used by read()
-            final byte[] buffer = new byte[readBuffer.length];
+            final byte[] buffer = new byte[readBufferSize(socket)];
             while (generation == readerGeneration.get() && socket.isConnected()) {
                 try {
                     int available = inputStream.available();
@@ -3476,6 +3481,9 @@ abstract class L2CapChannel {
     }
 
     public void read(String remoteId, int psm, final Result resultCallback) {
+        // snapshot: close() can modify these fields concurrently
+        final BluetoothSocket socket = this.socket;
+        final InputStream inputStream = this.inputStream;
         if (inputStream == null || socket == null || !socket.isConnected()) {
             resultCallback.error("no_socket_or_stream_is_open", "The bluetooth socket or the input stream is not open.", null);
             return;
@@ -3491,18 +3499,21 @@ abstract class L2CapChannel {
                 return;
             }
 
-            final int bytesRead = inputStream.read(readBuffer);
+            // fresh buffer per call: the reader loop may read concurrently, so a
+            // shared buffer could be overwritten between read and serialization
+            final byte[] buffer = new byte[readBufferSize(socket)];
+            final int bytesRead = inputStream.read(buffer);
+            final byte[] value = bytesRead > 0 ? Arrays.copyOf(buffer, bytesRead) : new byte[0];
             final Map<String, Object> responseData = new HashMap<>();
             responseData.put("remote_id", remoteId);
             responseData.put("psm", psm);
-            responseData.put("bytes_read", bytesRead);
-            responseData.put("value", readBuffer);
+            responseData.put("bytes_read", value.length);
+            responseData.put("value", value);
             resultCallback.success(responseData);
 
             // push event
             if (dataReceivedCallback != null && bytesRead > 0) {
-                byte[] emit = Arrays.copyOf(readBuffer, bytesRead);
-                dataReceivedCallback.data(socket.getRemoteDevice(), psm, emit);
+                dataReceivedCallback.data(socket.getRemoteDevice(), psm, value);
             }
         } catch (IOException e) {
             plugin.log(FlutterBlueMaxPlugin.LogLevel.ERROR, e.getMessage());
@@ -3563,11 +3574,7 @@ class L2CapClientChannel extends L2CapChannel {
     private final int psm;
 
     public L2CapClientChannel(final BluetoothDevice device, final int psm, final FlutterBlueMaxPlugin plugin) {
-        this(device, psm, DEFAULT_READ_BUFFER_SIZE, plugin);
-    }
-
-    public L2CapClientChannel(final BluetoothDevice device, final int psm, final int readBufferSize, final FlutterBlueMaxPlugin plugin) {
-        super(readBufferSize, plugin);
+        super(plugin);
         this.psm = psm;
         this.device = device;
     }
@@ -3616,11 +3623,7 @@ class L2CapServerChannel extends L2CapChannel {
 
 
     public L2CapServerChannel(final BluetoothSocket socket, final FlutterBlueMaxPlugin plugin) {
-        this(socket, DEFAULT_READ_BUFFER_SIZE, plugin);
-    }
-
-    public L2CapServerChannel(final BluetoothSocket socket, final int readBufferSize, final FlutterBlueMaxPlugin plugin) {
-        super(readBufferSize, plugin);
+        super(plugin);
         this.socket = socket;
     }
 

--- a/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
+++ b/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
@@ -58,6 +58,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.io.ByteArrayOutputStream;
@@ -3418,7 +3419,10 @@ abstract class L2CapChannel {
     protected OutputStream outputStream;
     protected InputStream inputStream;
     protected L2CapChannelManager.DataReceived dataReceivedCallback;
-    private volatile boolean readerRunning = false;
+    // Incremented whenever the current reader loop must stop (close, reconnect).
+    // Each reader thread only runs while its own generation is still current,
+    // so a reconnect can never end up with two threads competing for the stream.
+    private final AtomicInteger readerGeneration = new AtomicInteger(0);
 
     public L2CapChannel(final int readBufferSize, final FlutterBlueMaxPlugin plugin) {
         readBuffer = new byte[readBufferSize];
@@ -3433,23 +3437,38 @@ abstract class L2CapChannel {
         this.dataReceivedCallback = cb;
     }
 
-    public void startReaderLoop(final int psm) {
+    public synchronized void startReaderLoop(final int psm) {
+        // Snapshot socket and stream: the loop must never touch the mutable fields,
+        // which close() and reconnects modify from other threads (previously an NPE
+        // here would kill the whole app, as only IOException was caught).
+        final BluetoothSocket socket = this.socket;
+        final InputStream inputStream = this.inputStream;
         if (inputStream == null || socket == null) return;
-        readerRunning = true;
+        final BluetoothDevice remoteDevice = socket.getRemoteDevice();
+        final int generation = readerGeneration.incrementAndGet();
         new Thread(() -> {
-            while (readerRunning && socket != null && socket.isConnected()) {
+            // private buffer: the shared readBuffer is also used by read()
+            final byte[] buffer = new byte[readBuffer.length];
+            while (generation == readerGeneration.get() && socket.isConnected()) {
                 try {
                     int available = inputStream.available();
                     if (available <= 0) {
                         try { Thread.sleep(20); } catch (InterruptedException ignored) {}
                         continue;
                     }
-                    int bytesRead = inputStream.read(readBuffer);
-                    if (bytesRead > 0 && dataReceivedCallback != null) {
-                        byte[] emit = Arrays.copyOf(readBuffer, bytesRead);
-                        dataReceivedCallback.data(socket.getRemoteDevice(), psm, emit);
+                    int bytesRead = inputStream.read(buffer);
+                    if (bytesRead < 0) {
+                        break; // end of stream
+                    }
+                    if (bytesRead > 0 && generation == readerGeneration.get() && dataReceivedCallback != null) {
+                        byte[] emit = Arrays.copyOf(buffer, bytesRead);
+                        dataReceivedCallback.data(remoteDevice, psm, emit);
                     }
                 } catch (IOException e) {
+                    break;
+                } catch (Exception e) {
+                    // an uncaught exception on this thread would kill the app process
+                    plugin.log(FlutterBlueMaxPlugin.LogLevel.ERROR, "L2CAP reader loop error: " + e);
                     break;
                 }
             }
@@ -3507,7 +3526,8 @@ abstract class L2CapChannel {
     }
 
     public synchronized void close() {
-        readerRunning = false;
+        // invalidate the running reader; closing the streams below also unblocks it
+        readerGeneration.incrementAndGet();
         if (outputStream != null) {
             try {
                 outputStream.close();
@@ -3556,12 +3576,16 @@ class L2CapClientChannel extends L2CapChannel {
     @TargetApi(Build.VERSION_CODES.Q)
     public synchronized void connectToL2CapChannel(final boolean secure, final Result resultCallback) {
         try {
-            // Close existing socket if present before creating a new one
+            // Close existing socket if present before creating a new one.
+            // Also drop the old streams so a failed connect doesn't leave stale
+            // references to the closed socket (startReaderLoop checks them).
             if (socket != null) {
                 try {
                     socket.close();
                 } catch (IOException ignored) {}
                 socket = null;
+                inputStream = null;
+                outputStream = null;
             }
 
             if (secure) {

--- a/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
+++ b/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
@@ -3311,13 +3311,13 @@ class L2CapChannelManager {
         }
         final BluetoothDevice device = adapter.getRemoteDevice(remoteId);
 
-        L2CapInfo l2CapInfo = findInfo(psm);
-        if (l2CapInfo == null) {
-            plugin.log(FlutterBlueMaxPlugin.LogLevel.DEBUG, "L2CAP Channel with for device " + device.getAddress() + " / psm " + psm + " not open yet. Create channel.");
-            l2CapInfo = new ClientSocketInfo(new L2CapClientChannel(device, psm, plugin));
-            openL2CapChannelInfos.add(l2CapInfo);
+        ClientSocketInfo clientInfo = findClientInfo(device, psm);
+        if (clientInfo == null) {
+            plugin.log(FlutterBlueMaxPlugin.LogLevel.DEBUG, "L2CAP Channel for device " + device.getAddress() + " / psm " + psm + " not open yet. Create channel.");
+            clientInfo = new ClientSocketInfo(new L2CapClientChannel(device, psm, plugin));
+            openL2CapChannelInfos.add(clientInfo);
         }
-        final L2CapClientChannel l2CapChannel = ((L2CapClientChannel) l2CapInfo.getL2CapChannel(device));
+        final L2CapClientChannel l2CapChannel = ((L2CapClientChannel) clientInfo.getL2CapChannel(device));
         // set callbacks before connecting; the channel starts its reader loop
         // itself once the asynchronous connect succeeds
         l2CapChannel.setDataReceivedCallback(dataReceivedCallback);
@@ -3331,7 +3331,7 @@ class L2CapChannelManager {
             return;
         }
         final BluetoothDevice device = adapter.getRemoteDevice(remoteId);
-        final L2CapChannel channel = findChannel(psm, device);
+        final L2CapChannel channel = findChannel(device, psm);
         if (channel == null) {
             resultCallback.error("no_open_l2cap_channel_found", "No open channel found for device " + device.getAddress() + " / psm " + psm, null);
             return;
@@ -3345,7 +3345,7 @@ class L2CapChannelManager {
             return;
         }
         final BluetoothDevice device = adapter.getRemoteDevice(remoteId);
-        final L2CapChannel channel = findChannel(psm, device);
+        final L2CapChannel channel = findChannel(device, psm);
         if (channel == null) {
             resultCallback.error("no_open_l2cap_channel_found", "No open channel found for device " + device.getAddress() + " / psm " + psm, null);
             return;
@@ -3359,16 +3359,20 @@ class L2CapChannelManager {
             return;
         }
         final BluetoothDevice device = adapter.getRemoteDevice(remoteId);
-        final L2CapInfo channelInfo = findInfo(psm);
+        // prefer the client channel for this exact device+psm; fall back to a
+        // server-side channel accepted from this device
+        final ClientSocketInfo clientInfo = findClientInfo(device, psm);
+        final L2CapInfo channelInfo = clientInfo != null ? clientInfo : findServerInfo(psm);
         if (channelInfo != null) {
             try {
                 channelInfo.close(device);
             } catch (IOException e) {
                 plugin.log(FlutterBlueMaxPlugin.LogLevel.ERROR, e.getMessage());
                 resultCallback.error("close_l2cap_channel_failed", "Can't close channel with psm " + psm, null);
+                return; // returning both error and success would throw "Reply already submitted"
             }
-            if (channelInfo.getType() == L2CapInfo.Type.CLIENT) {
-                openL2CapChannelInfos.remove(channelInfo);
+            if (clientInfo != null) {
+                openL2CapChannelInfos.remove(clientInfo);
             }
         } else {
             plugin.log(FlutterBlueMaxPlugin.LogLevel.DEBUG, "No channel found which is matching device " + device.getAddress() + " / psm " + psm);
@@ -3377,10 +3381,10 @@ class L2CapChannelManager {
     }
 
     public synchronized void closeServerSocket(int psm, final Result resultCallback) {
-        final L2CapInfo channelInfo = findInfo(psm);
-        if (channelInfo != null && channelInfo.getType() == L2CapInfo.Type.SERVER) {
-            ((ServerSocketInfo) channelInfo).closeSocket();
-            openL2CapChannelInfos.remove(channelInfo);
+        final ServerSocketInfo serverInfo = findServerInfo(psm);
+        if (serverInfo != null) {
+            serverInfo.closeSocket();
+            openL2CapChannelInfos.remove(serverInfo);
         } else {
             plugin.log(FlutterBlueMaxPlugin.LogLevel.WARNING, "[FBP] No server socket found with psm " + psm);
         }
@@ -3391,23 +3395,48 @@ class L2CapChannelManager {
         resultCallback.error("platform_not_supported", "The device is running an older Android version. Minimum version is Android Q.", null);
     }
 
+    // Lookups must be keyed by device AND psm: the same PSM is commonly used by
+    // multiple devices of the same product (a fixed PSM in the firmware), and a
+    // PSM-only lookup then returns another device's channel — leading to NPEs,
+    // ClassCastExceptions, or closing the wrong device's channel.
     @Nullable
-    private L2CapInfo findInfo(final int psm) {
-        for (L2CapInfo channelInfo : openL2CapChannelInfos) {
-            if (psm == channelInfo.getPsm()) {
-                return channelInfo;
+    private ClientSocketInfo findClientInfo(final BluetoothDevice remoteDevice, final int psm) {
+        synchronized (openL2CapChannelInfos) {
+            for (L2CapInfo channelInfo : openL2CapChannelInfos) {
+                if (channelInfo.getType() == L2CapInfo.Type.CLIENT
+                        && psm == channelInfo.getPsm()
+                        && channelInfo.getL2CapChannel(remoteDevice) != null) {
+                    return (ClientSocketInfo) channelInfo;
+                }
             }
         }
         return null;
     }
 
     @Nullable
-    private L2CapChannel findChannel(final int psm, final BluetoothDevice remoteDevice) {
-        final L2CapInfo l2CapInfo = findInfo(psm);
-        if (l2CapInfo == null) {
-            return null;
+    private ServerSocketInfo findServerInfo(final int psm) {
+        synchronized (openL2CapChannelInfos) {
+            for (L2CapInfo channelInfo : openL2CapChannelInfos) {
+                if (channelInfo.getType() == L2CapInfo.Type.SERVER && psm == channelInfo.getPsm()) {
+                    return (ServerSocketInfo) channelInfo;
+                }
+            }
         }
-        return l2CapInfo.getL2CapChannel(remoteDevice);
+        return null;
+    }
+
+    @Nullable
+    private L2CapChannel findChannel(final BluetoothDevice remoteDevice, final int psm) {
+        final ClientSocketInfo clientInfo = findClientInfo(remoteDevice, psm);
+        if (clientInfo != null) {
+            return clientInfo.getL2CapChannel(remoteDevice);
+        }
+        // fall back to a server-side channel accepted from this device
+        final ServerSocketInfo serverInfo = findServerInfo(psm);
+        if (serverInfo != null) {
+            return serverInfo.getL2CapChannel(remoteDevice);
+        }
+        return null;
     }
 
 

--- a/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
+++ b/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
@@ -1602,7 +1602,7 @@ public class FlutterBlueMaxPlugin implements
                     l2CapChannelManager.write(remoteId, psm, value, result);
                     break;
                 }
-                case "listenL2capChannel":
+                case "listenL2CapChannel":
                 {
                     ArrayList<String> permissions = new ArrayList<>();
                     if (Build.VERSION.SDK_INT >= 31) { // Android 12 (October 2021)

--- a/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
+++ b/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
@@ -57,6 +57,9 @@ import java.util.UUID;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.io.StringWriter;
@@ -3315,11 +3318,11 @@ class L2CapChannelManager {
             openL2CapChannelInfos.add(l2CapInfo);
         }
         final L2CapClientChannel l2CapChannel = ((L2CapClientChannel) l2CapInfo.getL2CapChannel(device));
-        l2CapChannel.connectToL2CapChannel(secure, resultCallback);
-        // set callbacks and start reader loop
+        // set callbacks before connecting; the channel starts its reader loop
+        // itself once the asynchronous connect succeeds
         l2CapChannel.setDataReceivedCallback(dataReceivedCallback);
         l2CapChannel.setChannelClosedCallback(channelClosedCallback);
-        l2CapChannel.startReaderLoop(psm);
+        l2CapChannel.connectToL2CapChannel(secure, resultCallback);
     }
 
     public void read(String remoteId, int psm, final Result resultCallback) {
@@ -3468,6 +3471,20 @@ abstract class L2CapChannel {
         readerGeneration.incrementAndGet();
     }
 
+    // Single-threaded executor for this channel's blocking socket I/O (connect,
+    // write). One thread per channel keeps operations ordered — writes queue
+    // behind a pending connect — without blocking the main thread or other
+    // channels. Shut down by close().
+    protected final ExecutorService ioExecutor = Executors.newSingleThreadExecutor();
+
+    protected void runOnIoThread(final Runnable task, final Result resultCallback) {
+        try {
+            ioExecutor.execute(task);
+        } catch (RejectedExecutionException e) {
+            resultCallback.error("channel_closed", "The L2CAP channel is closed.", null);
+        }
+    }
+
     public synchronized void startReaderLoop(final int psm) {
         // Snapshot socket and stream: the loop must never touch the mutable fields,
         // which close() and reconnects modify from other threads (previously an NPE
@@ -3548,23 +3565,33 @@ abstract class L2CapChannel {
             }
         } catch (IOException e) {
             plugin.log(FlutterBlueMaxPlugin.LogLevel.ERROR, e.getMessage());
-            resultCallback.error("input_stream_read_failed", e.getMessage(), e);
+            // e.toString(), not e: an exception object is not codec-encodable
+            resultCallback.error("input_stream_read_failed", e.getMessage(), e.toString());
         }
     }
 
-    public void write(String remoteId, int psm, byte[] value, final Result resultCallback) {
-        if (outputStream == null || socket == null || !socket.isConnected()) {
-            resultCallback.error("no_socket_or_stream_is_open", "The bluetooth socket or the output stream is not open.", null);
-            return;
-        }
-        final byte[] data = value;
-        try {
-            outputStream.write(data);
-            resultCallback.success(null);
-        } catch (IOException e) {
-            plugin.log(FlutterBlueMaxPlugin.LogLevel.ERROR, e.getMessage());
-            resultCallback.error("output_stream_write_failed", e.getMessage(), e);
-        }
+    public void write(String remoteId, int psm, byte[] value, final Result rawResult) {
+        // OutputStream.write() blocks when the peer's L2CAP flow-control credits
+        // run out; on the main thread that froze the UI and stalled all other
+        // method calls. Run it on the io thread and post the result back.
+        final Result resultCallback = new MainThreadResult(rawResult);
+        runOnIoThread(() -> {
+            // snapshot inside the task: it runs after any queued connect, and
+            // close() can modify these fields concurrently
+            final BluetoothSocket socket = this.socket;
+            final OutputStream outputStream = this.outputStream;
+            if (outputStream == null || socket == null || !socket.isConnected()) {
+                resultCallback.error("no_socket_or_stream_is_open", "The bluetooth socket or the output stream is not open.", null);
+                return;
+            }
+            try {
+                outputStream.write(value);
+                resultCallback.success(null);
+            } catch (IOException e) {
+                plugin.log(FlutterBlueMaxPlugin.LogLevel.ERROR, e.getMessage());
+                resultCallback.error("output_stream_write_failed", e.getMessage(), e.toString());
+            }
+        }, resultCallback);
     }
 
     public synchronized void close() {
@@ -3597,6 +3624,9 @@ abstract class L2CapChannel {
                 socket = null;
             }
         }
+        // closing the socket above unblocks any in-flight connect/write; tasks
+        // still queued will fail fast on the closed streams
+        ioExecutor.shutdown();
     }
 }
 
@@ -3610,37 +3640,65 @@ class L2CapClientChannel extends L2CapChannel {
         this.device = device;
     }
 
+    public void connectToL2CapChannel(final boolean secure, final Result rawResult) {
+        // BluetoothSocket.connect() blocks, potentially for tens of seconds. On
+        // the main thread that froze the UI (ANR) and — because onMethodCall
+        // holds mMethodCallMutex — stalled GATT callbacks for all devices. Run
+        // it on the io thread and post the result back to the main thread.
+        final Result resultCallback = new MainThreadResult(rawResult);
+        runOnIoThread(() -> connectBlocking(secure, resultCallback), resultCallback);
+    }
+
     @SuppressLint("MissingPermission")
     @TargetApi(Build.VERSION_CODES.Q)
-    public synchronized void connectToL2CapChannel(final boolean secure, final Result resultCallback) {
+    private void connectBlocking(final boolean secure, final Result resultCallback) {
         try {
-            // Close existing socket if present before creating a new one.
-            // Also drop the old streams so a failed connect doesn't leave stale
-            // references to the closed socket (startReaderLoop checks them).
-            if (socket != null) {
-                // this close is intentional — stop the old reader without it
-                // reporting the channel as died
-                invalidateReader();
-                try {
-                    socket.close();
-                } catch (IOException ignored) {}
-                socket = null;
-                inputStream = null;
-                outputStream = null;
+            final BluetoothSocket newSocket;
+            synchronized (this) {
+                // Close existing socket if present before creating a new one.
+                // Also drop the old streams so a failed connect doesn't leave stale
+                // references to the closed socket (startReaderLoop checks them).
+                if (socket != null) {
+                    // this close is intentional — stop the old reader without it
+                    // reporting the channel as died
+                    invalidateReader();
+                    try {
+                        socket.close();
+                    } catch (IOException ignored) {}
+                    socket = null;
+                    inputStream = null;
+                    outputStream = null;
+                }
+
+                if (secure) {
+                    newSocket = device.createL2capChannel(psm);
+                } else {
+                    newSocket = device.createInsecureL2capChannel(psm);
+                }
+                socket = newSocket;
             }
 
-            if (secure) {
-                socket = device.createL2capChannel(psm);
-            } else {
-                socket = device.createInsecureL2capChannel(psm);
+            // blocking call — deliberately outside the monitor, so close() can
+            // abort a hanging connect by closing the socket
+            newSocket.connect();
+
+            synchronized (this) {
+                if (socket != newSocket) {
+                    // closed or replaced while connecting
+                    try {
+                        newSocket.close();
+                    } catch (IOException ignored) {}
+                    resultCallback.error("open_l2cap_channel_failed", "The channel was closed while connecting.", null);
+                    return;
+                }
+                inputStream = newSocket.getInputStream();
+                outputStream = newSocket.getOutputStream();
             }
-            socket.connect();
-            inputStream = socket.getInputStream();
-            outputStream = socket.getOutputStream();
+            startReaderLoop(psm);
             resultCallback.success(null);
         } catch (IOException e) {
             plugin.log(FlutterBlueMaxPlugin.LogLevel.ERROR, e.getMessage());
-            resultCallback.error("open_l2cap_channel_failed", e.getMessage(), e);
+            resultCallback.error("open_l2cap_channel_failed", e.getMessage(), e.toString());
         }
     }
 
@@ -3824,6 +3882,32 @@ class DeviceConnectedToL2CapChannel {
         this.psm = psm;
     }
 
+}
+
+// MethodChannel results must be invoked on the platform (main) thread; work
+// running on background threads wraps its Result with this.
+class MainThreadResult implements Result {
+    private final Result inner;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    MainThreadResult(final Result inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public void success(final Object result) {
+        handler.post(() -> inner.success(result));
+    }
+
+    @Override
+    public void error(final String errorCode, final String errorMessage, final Object errorDetails) {
+        handler.post(() -> inner.error(errorCode, errorMessage, errorDetails));
+    }
+
+    @Override
+    public void notImplemented() {
+        handler.post(inner::notImplemented);
+    }
 }
 
 

--- a/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
+++ b/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
@@ -137,11 +137,10 @@ public class FlutterBlueMaxPlugin implements
     private L2CapChannelManager l2CapChannelManager;
 
     private final L2CapChannelManager.DeviceConnected deviceConnectedCallback = (remoteDevice, psm) -> {
-        final DeviceConnectedToL2CapChannel newConnectedDeviceState = new DeviceConnectedToL2CapChannel(remoteDevice, psm);
-        final HashMap<String, Object> deviceConnectedData = new HashMap<>();
-        deviceConnectedData.put("psm", psm);
-        deviceConnectedData.put("bluetoothDevice", MarshallingUtil.bmBluetoothDevice(remoteDevice));
-        invokeMethodUIThread("connectToL2CapChannel", deviceConnectedData);
+        final HashMap<String, Object> data = new HashMap<>();
+        data.put("remote_id", remoteDevice.getAddress());
+        data.put("psm", psm);
+        invokeMethodUIThread("OnL2CapChannelConnected", data);
     };
 
     private final L2CapChannelManager.DataReceived dataReceivedCallback = (remoteDevice, psm, value) -> {
@@ -3330,10 +3329,9 @@ class L2CapChannelManager {
             firePlatformNotSupportedError(resultCallback);
             return;
         }
-        final BluetoothDevice device = adapter.getRemoteDevice(remoteId);
-        final L2CapChannel channel = findChannel(device, psm);
+        final L2CapChannel channel = findChannelForRemoteId(remoteId, psm);
         if (channel == null) {
-            resultCallback.error("no_open_l2cap_channel_found", "No open channel found for device " + device.getAddress() + " / psm " + psm, null);
+            resultCallback.error("no_open_l2cap_channel_found", "No open channel found for device " + remoteId + " / psm " + psm, null);
             return;
         }
         channel.read(remoteId, psm, resultCallback);
@@ -3344,10 +3342,9 @@ class L2CapChannelManager {
             firePlatformNotSupportedError(resultCallback);
             return;
         }
-        final BluetoothDevice device = adapter.getRemoteDevice(remoteId);
-        final L2CapChannel channel = findChannel(device, psm);
+        final L2CapChannel channel = findChannelForRemoteId(remoteId, psm);
         if (channel == null) {
-            resultCallback.error("no_open_l2cap_channel_found", "No open channel found for device " + device.getAddress() + " / psm " + psm, null);
+            resultCallback.error("no_open_l2cap_channel_found", "No open channel found for device " + remoteId + " / psm " + psm, null);
             return;
         }
         channel.write(remoteId, psm, value, resultCallback);
@@ -3356,6 +3353,17 @@ class L2CapChannelManager {
     public synchronized void closeChannel(String remoteId, int psm, final Result resultCallback) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             firePlatformNotSupportedError(resultCallback);
+            return;
+        }
+        if (SERVER_REMOTE_ID.equals(remoteId)) {
+            final ServerSocketInfo serverInfo = findServerInfo(psm);
+            final L2CapServerChannel channel = serverInfo != null ? serverInfo.getAnyL2CapChannel() : null;
+            if (channel != null) {
+                serverInfo.closeChannel(channel);
+            } else {
+                plugin.log(FlutterBlueMaxPlugin.LogLevel.DEBUG, "No server-accepted channel found for psm " + psm);
+            }
+            resultCallback.success(null);
             return;
         }
         final BluetoothDevice device = adapter.getRemoteDevice(remoteId);
@@ -3437,6 +3445,21 @@ class L2CapChannelManager {
             return serverInfo.getL2CapChannel(remoteDevice);
         }
         return null;
+    }
+
+    // iOS cannot know which central connected to an L2CAP server, so Dart may
+    // address a server-accepted channel with the placeholder remoteId "server".
+    // Accept it here too; data and close events still carry the client's real
+    // MAC address (which is likewise accepted, via findChannel's server fallback).
+    static final String SERVER_REMOTE_ID = "server";
+
+    @Nullable
+    private L2CapChannel findChannelForRemoteId(final String remoteId, final int psm) {
+        if (SERVER_REMOTE_ID.equals(remoteId)) {
+            final ServerSocketInfo serverInfo = findServerInfo(psm);
+            return serverInfo != null ? serverInfo.getAnyL2CapChannel() : null;
+        }
+        return findChannel(adapter.getRemoteDevice(remoteId), psm);
     }
 
 
@@ -3863,8 +3886,21 @@ class ServerSocketInfo implements L2CapInfo {
         if (channelToDelete == null) {
             return;
         }
-        channelToDelete.close();
-        openChannels.remove(channelToDelete);
+        closeChannel(channelToDelete);
+    }
+
+    // For operations addressed with the placeholder remoteId "server" (see
+    // L2CapChannelManager.SERVER_REMOTE_ID): the first accepted channel.
+    @Nullable
+    L2CapServerChannel getAnyL2CapChannel() {
+        synchronized (openChannels) {
+            return openChannels.isEmpty() ? null : openChannels.get(0);
+        }
+    }
+
+    void closeChannel(final L2CapServerChannel channel) {
+        channel.close();
+        openChannels.remove(channel);
     }
 
     public void acceptConnections() {
@@ -3915,17 +3951,6 @@ class ServerSocketInfo implements L2CapInfo {
 
 
 
-
-class DeviceConnectedToL2CapChannel {
-    public final BluetoothDevice device;
-    public final int psm;
-
-    public DeviceConnectedToL2CapChannel(BluetoothDevice device, int psm) {
-        this.device = device;
-        this.psm = psm;
-    }
-
-}
 
 // MethodChannel results must be invoked on the platform (main) thread; work
 // running on background threads wraps its Result with this.

--- a/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
+++ b/packages/flutter_blue_max_android/android/src/main/java/com/lib/flutter_blue_max/FlutterBlueMaxPlugin.java
@@ -149,6 +149,13 @@ public class FlutterBlueMaxPlugin implements
         invokeMethodUIThread("OnL2CapChannelReceived", data);
     };
 
+    private final L2CapChannelManager.ChannelClosed channelClosedCallback = (remoteDevice, psm) -> {
+        final HashMap<String, Object> data = new HashMap<>();
+        data.put("remote_id", remoteDevice.getAddress());
+        data.put("psm", psm);
+        invokeMethodUIThread("OnL2CapChannelClosed", data);
+    };
+
     private interface OperationOnPermission {
         void op(boolean granted, String permission);
     }
@@ -347,7 +354,7 @@ public class FlutterBlueMaxPlugin implements
                 return;
             }
             if (l2CapChannelManager == null) {
-                l2CapChannelManager = new L2CapChannelManager(mBluetoothAdapter, deviceConnectedCallback, dataReceivedCallback, this);
+                l2CapChannelManager = new L2CapChannelManager(mBluetoothAdapter, deviceConnectedCallback, dataReceivedCallback, channelClosedCallback, this);
             }
 
             switch (call.method) {
@@ -3247,13 +3254,15 @@ class L2CapChannelManager {
     private final BluetoothAdapter adapter;
     private final DeviceConnected deviceConnectedCallback;
     private final DataReceived dataReceivedCallback;
+    private final ChannelClosed channelClosedCallback;
     private final FlutterBlueMaxPlugin plugin;
     private final List<L2CapInfo> openL2CapChannelInfos = Collections.synchronizedList(new LinkedList<>());
 
-    public L2CapChannelManager(@NonNull final BluetoothAdapter adapter, @NonNull final DeviceConnected deviceConnectedCallback, @NonNull final DataReceived dataReceivedCallback, @NonNull final FlutterBlueMaxPlugin plugin) {
+    public L2CapChannelManager(@NonNull final BluetoothAdapter adapter, @NonNull final DeviceConnected deviceConnectedCallback, @NonNull final DataReceived dataReceivedCallback, @NonNull final ChannelClosed channelClosedCallback, @NonNull final FlutterBlueMaxPlugin plugin) {
         this.adapter = adapter;
         this.deviceConnectedCallback = deviceConnectedCallback;
         this.dataReceivedCallback = dataReceivedCallback;
+        this.channelClosedCallback = channelClosedCallback;
         this.plugin = plugin;
     }
 
@@ -3276,7 +3285,7 @@ class L2CapChannelManager {
             } else {
                 serverSocket = adapter.listenUsingInsecureL2capChannel();
             }
-            final ServerSocketInfo socketInfo = new ServerSocketInfo(serverSocket, deviceConnectedCallback, dataReceivedCallback, plugin);
+            final ServerSocketInfo socketInfo = new ServerSocketInfo(serverSocket, deviceConnectedCallback, dataReceivedCallback, channelClosedCallback, plugin);
             openL2CapChannelInfos.add(socketInfo);
             final int psm = serverSocket.getPsm();
             socketInfo.acceptConnections();
@@ -3307,8 +3316,9 @@ class L2CapChannelManager {
         }
         final L2CapClientChannel l2CapChannel = ((L2CapClientChannel) l2CapInfo.getL2CapChannel(device));
         l2CapChannel.connectToL2CapChannel(secure, resultCallback);
-        // set data callback and start reader loop
+        // set callbacks and start reader loop
         l2CapChannel.setDataReceivedCallback(dataReceivedCallback);
+        l2CapChannel.setChannelClosedCallback(channelClosedCallback);
         l2CapChannel.startReaderLoop(psm);
     }
 
@@ -3405,6 +3415,10 @@ class L2CapChannelManager {
     public interface DataReceived {
         void data(BluetoothDevice remoteDevice, int psm, byte[] value);
     }
+
+    public interface ChannelClosed {
+        void closed(BluetoothDevice remoteDevice, int psm);
+    }
 }
 
 
@@ -3417,6 +3431,7 @@ abstract class L2CapChannel {
     protected OutputStream outputStream;
     protected InputStream inputStream;
     protected L2CapChannelManager.DataReceived dataReceivedCallback;
+    protected L2CapChannelManager.ChannelClosed channelClosedCallback;
     // Incremented whenever the current reader loop must stop (close, reconnect).
     // Each reader thread only runs while its own generation is still current,
     // so a reconnect can never end up with two threads competing for the stream.
@@ -3441,6 +3456,16 @@ abstract class L2CapChannel {
 
     public void setDataReceivedCallback(L2CapChannelManager.DataReceived cb) {
         this.dataReceivedCallback = cb;
+    }
+
+    public void setChannelClosedCallback(L2CapChannelManager.ChannelClosed cb) {
+        this.channelClosedCallback = cb;
+    }
+
+    // Stop the current reader loop without notifying Dart — for intentional
+    // teardown (close, reconnect), as opposed to the channel dying on its own.
+    protected void invalidateReader() {
+        readerGeneration.incrementAndGet();
     }
 
     public synchronized void startReaderLoop(final int psm) {
@@ -3476,6 +3501,12 @@ abstract class L2CapChannel {
                     plugin.log(FlutterBlueMaxPlugin.LogLevel.ERROR, "L2CAP reader loop error: " + e);
                     break;
                 }
+            }
+            // If our generation is still current, the loop ended because the channel
+            // died on its own (EOF, IO error, disconnect) — not because close() or a
+            // reconnect intentionally stopped it. Tell Dart the channel is gone.
+            if (generation == readerGeneration.get() && channelClosedCallback != null) {
+                channelClosedCallback.closed(remoteDevice, psm);
             }
         }).start();
     }
@@ -3538,7 +3569,7 @@ abstract class L2CapChannel {
 
     public synchronized void close() {
         // invalidate the running reader; closing the streams below also unblocks it
-        readerGeneration.incrementAndGet();
+        invalidateReader();
         if (outputStream != null) {
             try {
                 outputStream.close();
@@ -3587,6 +3618,9 @@ class L2CapClientChannel extends L2CapChannel {
             // Also drop the old streams so a failed connect doesn't leave stale
             // references to the closed socket (startReaderLoop checks them).
             if (socket != null) {
+                // this close is intentional — stop the old reader without it
+                // reporting the channel as died
+                invalidateReader();
                 try {
                     socket.close();
                 } catch (IOException ignored) {}
@@ -3691,13 +3725,15 @@ class ServerSocketInfo implements L2CapInfo {
     private final List<L2CapServerChannel> openChannels;
     private final L2CapChannelManager.DeviceConnected deviceConnectedCallback;
     private final L2CapChannelManager.DataReceived dataReceivedCallback;
+    private final L2CapChannelManager.ChannelClosed channelClosedCallback;
     private final FlutterBlueMaxPlugin plugin;
     private boolean isAcceptingConnections;
 
-    public ServerSocketInfo(BluetoothServerSocket serverSocket, final L2CapChannelManager.DeviceConnected deviceConnectedCallback, final L2CapChannelManager.DataReceived dataReceivedCallback, final FlutterBlueMaxPlugin plugin) {
+    public ServerSocketInfo(BluetoothServerSocket serverSocket, final L2CapChannelManager.DeviceConnected deviceConnectedCallback, final L2CapChannelManager.DataReceived dataReceivedCallback, final L2CapChannelManager.ChannelClosed channelClosedCallback, final FlutterBlueMaxPlugin plugin) {
         this.serverSocket = serverSocket;
         this.deviceConnectedCallback = deviceConnectedCallback;
         this.dataReceivedCallback = dataReceivedCallback;
+        this.channelClosedCallback = channelClosedCallback;
         this.plugin = plugin;
         openChannels = Collections.synchronizedList(new LinkedList<>());
         isAcceptingConnections = false;
@@ -3750,6 +3786,7 @@ class ServerSocketInfo implements L2CapInfo {
                     final L2CapServerChannel l2capChannel = new L2CapServerChannel(socket, plugin);
                     l2capChannel.openStreams();
                     l2capChannel.setDataReceivedCallback(dataReceivedCallback);
+                    l2capChannel.setChannelClosedCallback(channelClosedCallback);
                     l2capChannel.startReaderLoop(getPsm());
                     addConnection(l2capChannel);
                     deviceConnectedCallback.deviceConnected(socket.getRemoteDevice(), getPsm());

--- a/packages/flutter_blue_max_android/lib/flutter_blue_max_android.dart
+++ b/packages/flutter_blue_max_android/lib/flutter_blue_max_android.dart
@@ -263,7 +263,10 @@ final class FlutterBlueMaxAndroid extends FlutterBlueMaxPlatform {
   Future<int> listenL2CapChannel(
     ListenL2CapChannelRequest request,
   ) async {
-    var result = await _invokeMethod('listenL2CapChannel', request.toMap());
+    // must be spelled "listenL2capChannel" — this is the method name the native
+    // side handles (same on Android and iOS); "listenL2CapChannel" falls through
+    // to notImplemented and throws MissingPluginException
+    var result = await _invokeMethod('listenL2capChannel', request.toMap());
     return result is Map ? (result['psm'] as int? ?? 4097) : 4097;
   }
 

--- a/packages/flutter_blue_max_android/lib/flutter_blue_max_android.dart
+++ b/packages/flutter_blue_max_android/lib/flutter_blue_max_android.dart
@@ -29,6 +29,7 @@ final class FlutterBlueMaxAndroid extends FlutterBlueMaxPlatform {
   final _onServicesResetController = StreamController<BmBluetoothDevice>.broadcast();
   final _onTurnOnResponseController = StreamController<BmTurnOnResponse>.broadcast();
   final _onL2CapChannelReceivedController = StreamController<L2CapChannelData>.broadcast();
+  final _onL2CapChannelClosedController = StreamController<L2CapChannelClosed>.broadcast();
 
   @override
   Stream<BmBluetoothAdapterState> get onAdapterStateChanged {
@@ -103,6 +104,11 @@ final class FlutterBlueMaxAndroid extends FlutterBlueMaxPlatform {
   @override
   Stream<L2CapChannelData> get onL2CapChannelReceived {
     return _onL2CapChannelReceivedController.stream;
+  }
+
+  @override
+  Stream<L2CapChannelClosed> get onL2CapChannelClosed {
+    return _onL2CapChannelClosedController.stream;
   }
 
   @override
@@ -621,6 +627,12 @@ final class FlutterBlueMaxAndroid extends FlutterBlueMaxPlatform {
       case 'OnL2CapChannelReceived':
         return _onL2CapChannelReceivedController.add(
           L2CapChannelData.fromMap(
+            call.arguments,
+          ),
+        );
+      case 'OnL2CapChannelClosed':
+        return _onL2CapChannelClosedController.add(
+          L2CapChannelClosed.fromMap(
             call.arguments,
           ),
         );

--- a/packages/flutter_blue_max_android/lib/flutter_blue_max_android.dart
+++ b/packages/flutter_blue_max_android/lib/flutter_blue_max_android.dart
@@ -30,6 +30,7 @@ final class FlutterBlueMaxAndroid extends FlutterBlueMaxPlatform {
   final _onTurnOnResponseController = StreamController<BmTurnOnResponse>.broadcast();
   final _onL2CapChannelReceivedController = StreamController<L2CapChannelData>.broadcast();
   final _onL2CapChannelClosedController = StreamController<L2CapChannelClosed>.broadcast();
+  final _onL2CapChannelConnectedController = StreamController<L2CapChannelConnected>.broadcast();
 
   @override
   Stream<BmBluetoothAdapterState> get onAdapterStateChanged {
@@ -109,6 +110,11 @@ final class FlutterBlueMaxAndroid extends FlutterBlueMaxPlatform {
   @override
   Stream<L2CapChannelClosed> get onL2CapChannelClosed {
     return _onL2CapChannelClosedController.stream;
+  }
+
+  @override
+  Stream<L2CapChannelConnected> get onL2CapChannelConnected {
+    return _onL2CapChannelConnectedController.stream;
   }
 
   @override
@@ -633,6 +639,12 @@ final class FlutterBlueMaxAndroid extends FlutterBlueMaxPlatform {
       case 'OnL2CapChannelClosed':
         return _onL2CapChannelClosedController.add(
           L2CapChannelClosed.fromMap(
+            call.arguments,
+          ),
+        );
+      case 'OnL2CapChannelConnected':
+        return _onL2CapChannelConnectedController.add(
+          L2CapChannelConnected.fromMap(
             call.arguments,
           ),
         );

--- a/packages/flutter_blue_max_android/lib/flutter_blue_max_android.dart
+++ b/packages/flutter_blue_max_android/lib/flutter_blue_max_android.dart
@@ -263,10 +263,7 @@ final class FlutterBlueMaxAndroid extends FlutterBlueMaxPlatform {
   Future<int> listenL2CapChannel(
     ListenL2CapChannelRequest request,
   ) async {
-    // must be spelled "listenL2capChannel" — this is the method name the native
-    // side handles (same on Android and iOS); "listenL2CapChannel" falls through
-    // to notImplemented and throws MissingPluginException
-    var result = await _invokeMethod('listenL2capChannel', request.toMap());
+    var result = await _invokeMethod('listenL2CapChannel', request.toMap());
     return result is Map ? (result['psm'] as int? ?? 4097) : 4097;
   }
 

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -916,7 +916,7 @@ static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
         {
             [self.l2CapChannelManager handleWriteL2CapChannel:call result:result];
         }
-        else if([@"listenL2capChannel" isEqualToString:call.method])
+        else if([@"listenL2CapChannel" isEqualToString:call.method])
         {
             [self.l2CapChannelManager handleListenL2capChannel:call result:result];
         }

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -61,11 +61,22 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 @class L2CapChannelManager;
 @class L2CapChannelInfo;
 
+// A queued outgoing write. NSOutputStream may accept fewer bytes than offered
+// (partial write) or none at all (no space); the unwritten remainder stays
+// queued and is flushed on HasSpaceAvailable. The Dart result completes only
+// once every byte has been handed to the stream.
+@interface L2CapPendingWrite : NSObject
+@property(nonatomic) NSData *data;
+@property(nonatomic) NSUInteger offset;
+@property(nonatomic, copy) FlutterResult completion;
+@end
+
 @interface L2CapChannelInfo : NSObject
 @property(nonatomic) NSNumber *psm;
 @property(nonatomic) NSString *remoteId;
 @property(nonatomic) CBL2CAPChannel *channel;
 @property(nonatomic) NSMutableData *readBuffer;
+@property(nonatomic) NSMutableArray<L2CapPendingWrite *> *pendingWrites;
 @property(nonatomic, getter=isListening) BOOL listening;
 - (instancetype)initWithPsm:(NSNumber *)psm remoteId:(NSString *)remoteId channel:(CBL2CAPChannel *)channel;
 @end
@@ -103,6 +114,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 - (void)reattachStreamsForChannel:(L2CapChannelInfo *)channelInfo;
 - (void)cleanupChannelsForPeripheral:(NSString *)remoteId;
 - (void)completePendingOpenForRemoteId:(NSString *)remoteId psm:(CBL2CAPPSM)psm error:(NSError *)error;
+- (void)drainWritesForChannel:(L2CapChannelInfo *)channelInfo;
+- (void)failPendingWritesForChannel:(L2CapChannelInfo *)channelInfo error:(FlutterError *)error;
 @end
 
 @interface FlutterBlueMaxPlugin ()
@@ -2433,6 +2446,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 // ██       ██   ██  ██   ██  ██  ██ ██  ██  ██ ██  ██       ██
 //  ██████  ██   ██  ██   ██  ██   ████  ██   ████  ███████  ███████
 
+@implementation L2CapPendingWrite
+@end
+
 @implementation L2CapChannelInfo
 - (instancetype)initWithPsm:(NSNumber *)psm remoteId:(NSString *)remoteId channel:(CBL2CAPChannel *)channel
 {
@@ -2442,6 +2458,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         self.remoteId = remoteId;
         self.channel = channel;
         self.readBuffer = [[NSMutableData alloc] init];
+        self.pendingWrites = [[NSMutableArray alloc] init];
         self.listening = NO;
     }
     return self;
@@ -2610,6 +2627,12 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
             [is removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
             [os removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
 
+            // Writes still queued at close time can never complete — fail them
+            [self failPendingWritesForChannel:channelInfo
+                                        error:[FlutterError errorWithCode:@"writeL2CapChannel"
+                                                                  message:@"L2CAP channel closed"
+                                                                  details:nil]];
+
             // Move to zombie list instead of removing. This keeps the CBL2CAPChannel
             // object alive so ARC doesn't dealloc it. Releasing a CBL2CAPChannel
             // triggers iOS to disconnect ALL L2CAP channels on the same peripheral.
@@ -2665,25 +2688,68 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     }
     
     if (channelInfo && channelInfo.channel && channelInfo.channel.outputStream) {
-        NSOutputStream *outputStream = channelInfo.channel.outputStream;
-        if (outputStream.hasSpaceAvailable) {
-            NSInteger bytesWritten = [outputStream write:valueData.data.bytes maxLength:valueData.data.length];
-            if (bytesWritten < 0) {
-                result([FlutterError errorWithCode:@"writeL2CapChannel"
-                                          message:@"Write failed"
-                                          details:nil]);
-            } else {
-                result(nil);
-            }
-        } else {
-            result([FlutterError errorWithCode:@"writeL2CapChannel"
-                                      message:@"Output stream not ready"
-                                      details:nil]);
+        if (valueData.data.length == 0) {
+            result(nil);
+            return;
         }
+        // Queue the write and drain as much as the stream accepts right now.
+        // Writing directly would silently drop bytes: NSOutputStream can accept
+        // fewer bytes than offered, and has no space at all under backpressure.
+        L2CapPendingWrite *pendingWrite = [[L2CapPendingWrite alloc] init];
+        pendingWrite.data = valueData.data;
+        pendingWrite.offset = 0;
+        pendingWrite.completion = result;
+        [channelInfo.pendingWrites addObject:pendingWrite];
+        [self drainWritesForChannel:channelInfo];
     } else {
-        result([FlutterError errorWithCode:@"writeL2CapChannel" 
-                                  message:@"Channel not found" 
+        result([FlutterError errorWithCode:@"writeL2CapChannel"
+                                  message:@"Channel not found"
                                   details:nil]);
+    }
+}
+
+// Write queued data until the stream stops accepting bytes. The remainder is
+// flushed by the next HasSpaceAvailable event (or the next queued write).
+- (void)drainWritesForChannel:(L2CapChannelInfo *)channelInfo
+{
+    NSOutputStream *outputStream = channelInfo.channel.outputStream;
+    while (channelInfo.pendingWrites.count > 0 && outputStream.hasSpaceAvailable) {
+        L2CapPendingWrite *pendingWrite = channelInfo.pendingWrites.firstObject;
+        const uint8_t *bytes = (const uint8_t *)pendingWrite.data.bytes + pendingWrite.offset;
+        NSUInteger remaining = pendingWrite.data.length - pendingWrite.offset;
+        NSInteger written = [outputStream write:bytes maxLength:remaining];
+        if (written < 0) {
+            NSString *message = outputStream.streamError.localizedDescription ?: @"Write failed";
+            [channelInfo.pendingWrites removeObjectAtIndex:0];
+            pendingWrite.completion([FlutterError errorWithCode:@"writeL2CapChannel"
+                                                        message:message
+                                                        details:nil]);
+            return;
+        }
+        if (written == 0) {
+            // stream accepted nothing despite hasSpaceAvailable — wait for the
+            // next HasSpaceAvailable event instead of spinning on the main thread
+            return;
+        }
+        pendingWrite.offset += written;
+        if (pendingWrite.offset >= pendingWrite.data.length) {
+            [channelInfo.pendingWrites removeObjectAtIndex:0];
+            pendingWrite.completion(nil);
+        }
+    }
+}
+
+// Fail every queued write, e.g. when the channel dies or the device disconnects.
+// Leaving them queued would hang the Dart write futures forever.
+- (void)failPendingWritesForChannel:(L2CapChannelInfo *)channelInfo error:(FlutterError *)error
+{
+    if (channelInfo.pendingWrites.count == 0) {
+        return;
+    }
+    NSArray<L2CapPendingWrite *> *failed = [channelInfo.pendingWrites copy];
+    [channelInfo.pendingWrites removeAllObjects];
+    for (L2CapPendingWrite *pendingWrite in failed) {
+        pendingWrite.completion(error);
     }
 }
 
@@ -2937,6 +3003,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
                     [self.pendingStreamReady removeObjectForKey:readyKey];
                     pendingBlock(nil);
                 }
+                [self drainWritesForChannel:channelInfo];
             }
             break;
         case NSStreamEventErrorOccurred:
@@ -2990,6 +3057,11 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
                                               userInfo:@{NSLocalizedDescriptionKey: @"L2CAP stream ended before becoming ready"}]);
     }
 
+    [self failPendingWritesForChannel:channelInfo
+                                error:[FlutterError errorWithCode:@"writeL2CapChannel"
+                                                          message:error.localizedDescription ?: @"L2CAP channel closed"
+                                                          details:nil]];
+
     [self.methodChannel invokeMethod:@"OnL2CapChannelClosed" arguments:@{
         @"remote_id": channelInfo.remoteId,
         @"psm": channelInfo.psm
@@ -3027,6 +3099,10 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     for (L2CapChannelInfo *info in self.channels) {
         if ([info.remoteId isEqualToString:remoteId]) {
             [toRemove addObject:info];
+            [self failPendingWritesForChannel:info
+                                        error:[FlutterError errorWithCode:@"writeL2CapChannel"
+                                                                  message:@"device disconnected"
+                                                                  details:nil]];
         }
     }
     [self.channels removeObjectsInArray:toRemove];

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -67,6 +67,12 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 // entire traffic in memory until the OS kills the app.
 static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
 
+// How much a single HasBytesAvailable handler pass drains from the input
+// stream before yielding back to the run loop. Bounds main-thread work per
+// pass; a remaining backlog is drained on the next pass (see
+// handleBytesAvailableForChannel).
+static const NSUInteger kL2CapDrainBudgetPerPass = 64 * 1024;
+
 // A queued outgoing write. NSOutputStream may accept fewer bytes than offered
 // (partial write) or none at all (no space); the unwritten remainder stays
 // queued and is flushed on HasSpaceAvailable. The Dart result completes only
@@ -3074,11 +3080,23 @@ static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
 {
     if (@available(iOS 11.0, *)) {
         NSInputStream *inputStream = channelInfo.channel.inputStream;
-        uint8_t buffer[1024];
-        NSInteger bytesRead = [inputStream read:buffer maxLength:sizeof(buffer)];
-        
-        if (bytesRead > 0) {
-            [channelInfo.readBuffer appendBytes:buffer length:bytesRead];
+        // Drain everything the OS has buffered, not just one fixed-size read:
+        // HasBytesAvailable is not guaranteed to fire again for data that is
+        // already buffered (only when new data arrives), so a single read
+        // could strand a backlog in the socket until the peer sends more.
+        NSMutableData *received = [[NSMutableData alloc] init];
+        uint8_t buffer[4096];
+        while (inputStream.hasBytesAvailable && received.length < kL2CapDrainBudgetPerPass) {
+            NSInteger bytesRead = [inputStream read:buffer maxLength:sizeof(buffer)];
+            if (bytesRead <= 0) {
+                // 0: nothing more; <0: error — the stream delivers ErrorOccurred separately
+                break;
+            }
+            [received appendBytes:buffer length:bytesRead];
+        }
+
+        if (received.length > 0) {
+            [channelInfo.readBuffer appendData:received];
             // keep only the most recent bytes (drop-oldest) — see kL2CapReadBufferCap
             if (channelInfo.readBuffer.length > kL2CapReadBufferCap) {
                 NSUInteger excess = channelInfo.readBuffer.length - kL2CapReadBufferCap;
@@ -3088,8 +3106,20 @@ static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
             [self.methodChannel invokeMethod:@"OnL2CapChannelReceived" arguments:@{
                 @"remote_id": channelInfo.remoteId,
                 @"psm": channelInfo.psm,
-                @"value": [NSData dataWithBytes:buffer length:bytesRead]
+                @"value": [NSData dataWithData:received]
             }];
+        }
+
+        // Budget exhausted with data still buffered: schedule the next drain
+        // pass ourselves instead of relying on another HasBytesAvailable event
+        // (which may never come for already-buffered data). Yielding between
+        // passes keeps a large backlog from monopolizing the main run loop.
+        if (inputStream.hasBytesAvailable) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                // the channel may have been closed or zombified in the meantime
+                if (![self.channels containsObject:channelInfo]) return;
+                [self handleBytesAvailableForChannel:channelInfo];
+            });
         }
     }
 }

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -61,6 +61,12 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 @class L2CapChannelManager;
 @class L2CapChannelInfo;
 
+// Cap for the per-channel poll buffer drained by readL2CapChannel. Received
+// data is also pushed via the OnL2CapChannelReceived event; without a cap,
+// apps that only consume the event stream would accumulate the channel's
+// entire traffic in memory until the OS kills the app.
+static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
+
 // A queued outgoing write. NSOutputStream may accept fewer bytes than offered
 // (partial write) or none at all (no space); the unwritten remainder stays
 // queued and is flushed on HasSpaceAvailable. The Dart result completes only
@@ -2533,6 +2539,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         }
         if (zombie && zombie.channel) {
             [self.zombieChannels removeObject:zombie];
+            // Drop data buffered before the channel was closed so the recycled
+            // channel doesn't hand the previous session's bytes to the new one.
+            [zombie.readBuffer setLength:0];
             [self.channels addObject:zombie];
             [self reattachStreamsForChannel:zombie];
 
@@ -2958,6 +2967,18 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
                 return;
             }
 
+            // Discard bytes the peer sent while the channel was logically closed
+            // (the OS channel stays open for zombies, so incoming data piles up
+            // in the socket buffer). Nothing here can belong to the new session:
+            // recycling is purely local, so the peer cannot have responded yet.
+            uint8_t drainBuffer[1024];
+            while (channel.inputStream.hasBytesAvailable) {
+                NSInteger drained = [channel.inputStream read:drainBuffer maxLength:sizeof(drainBuffer)];
+                if (drained <= 0) {
+                    break;
+                }
+            }
+
             // The output stream may already have space available. Since we just
             // re-attached to the run loop, HasSpaceAvailable might not fire again.
             // Check immediately and fire any pending callback.
@@ -3029,7 +3050,12 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         
         if (bytesRead > 0) {
             [channelInfo.readBuffer appendBytes:buffer length:bytesRead];
-            
+            // keep only the most recent bytes (drop-oldest) — see kL2CapReadBufferCap
+            if (channelInfo.readBuffer.length > kL2CapReadBufferCap) {
+                NSUInteger excess = channelInfo.readBuffer.length - kL2CapReadBufferCap;
+                [channelInfo.readBuffer replaceBytesInRange:NSMakeRange(0, excess) withBytes:NULL length:0];
+            }
+
             [self.methodChannel invokeMethod:@"OnL2CapChannelReceived" arguments:@{
                 @"remote_id": channelInfo.remoteId,
                 @"psm": channelInfo.psm,

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -3103,6 +3103,12 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
                                         error:[FlutterError errorWithCode:@"writeL2CapChannel"
                                                                   message:@"device disconnected"
                                                                   details:nil]];
+            // The stream End/Error events may never be delivered for a dropped
+            // connection, so report the close from here as well.
+            [self.methodChannel invokeMethod:@"OnL2CapChannelClosed" arguments:@{
+                @"remote_id": info.remoteId,
+                @"psm": info.psm
+            }];
         }
     }
     [self.channels removeObjectsInArray:toRemove];

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -85,7 +85,10 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 // Blocks to execute when the output stream becomes ready (HasSpaceAvailable).
 // Keyed by "<remoteId>:<psm>". Used to defer the open result until the stream
 // is actually writable, preventing "Output stream not ready" errors.
-@property(nonatomic) NSMutableDictionary<NSString *, void(^)(void)> *pendingStreamReady;
+// Called with nil on success, or with an error when the channel dies before
+// becoming ready (stream error/end, peripheral disconnect) — every path must
+// invoke the block, otherwise the Dart open future hangs forever.
+@property(nonatomic) NSMutableDictionary<NSString *, void(^)(NSError *)> *pendingStreamReady;
 @property(nonatomic, copy) FlutterResult pendingListenResult;
 @property(nonatomic) BOOL pendingListenSecure;
 - (instancetype)initWithMethodChannel:(FlutterMethodChannel *)methodChannel plugin:(FlutterBlueMaxPlugin *)plugin;
@@ -2401,10 +2404,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     // setupStreamsForChannel dispatches async, so the stream isn't ready yet.
     NSString *readyKey = [NSString stringWithFormat:@"%@:%@", remoteId, @(channel.PSM)];
     __weak typeof(self) weakSelf = self;
-    self.l2CapChannelManager.pendingStreamReady[readyKey] = ^{
+    self.l2CapChannelManager.pendingStreamReady[readyKey] = ^(NSError *readyError) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) return;
-        [strongSelf.l2CapChannelManager completePendingOpenForRemoteId:remoteId psm:channel.PSM error:nil];
+        [strongSelf.l2CapChannelManager completePendingOpenForRemoteId:remoteId psm:channel.PSM error:readyError];
+        if (readyError) {
+            return;
+        }
         [strongSelf.methodChannel invokeMethod:@"OnL2CapChannelOpened" arguments:@{
             @"remote_id": remoteId,
             @"psm": @(channel.PSM)
@@ -2518,9 +2524,15 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
             NSString *readyKey = [NSString stringWithFormat:@"%@:%@", remoteId, psmValue];
             FlutterResult capturedResult = [result copy];
             __weak typeof(self) weakSelf = self;
-            self.pendingStreamReady[readyKey] = ^{
+            self.pendingStreamReady[readyKey] = ^(NSError *readyError) {
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 if (!strongSelf) return;
+                if (readyError) {
+                    capturedResult([FlutterError errorWithCode:@"openL2CapChannel"
+                                                       message:readyError.localizedDescription
+                                                       details:@(readyError.code)]);
+                    return;
+                }
                 [strongSelf.methodChannel invokeMethod:@"OnL2CapChannelOpened" arguments:@{
                     @"remote_id": remoteId,
                     @"psm": psmValue
@@ -2849,15 +2861,45 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
             [channel.outputStream scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
             // Do NOT call open — streams are already open from the original channel setup
 
+            NSString *readyKey = [NSString stringWithFormat:@"%@:%@", channelInfo.remoteId, channelInfo.psm];
+
+            // The channel may have died while zombified (peer closed it, but the
+            // delegates were detached so we never got the event). Fail the pending
+            // open instead of waiting for a HasSpaceAvailable that never fires.
+            // Streams whose death isn't reflected in streamStatus yet will deliver
+            // an End/Error event now that they are re-scheduled, which also fails
+            // the pending open via handleStreamEndForChannel.
+            NSStreamStatus inStatus = channel.inputStream.streamStatus;
+            NSStreamStatus outStatus = channel.outputStream.streamStatus;
+            BOOL streamDead = inStatus == NSStreamStatusAtEnd || inStatus == NSStreamStatusClosed || inStatus == NSStreamStatusError
+                           || outStatus == NSStreamStatusAtEnd || outStatus == NSStreamStatusClosed || outStatus == NSStreamStatusError;
+            if (streamDead) {
+                channel.inputStream.delegate = nil;
+                channel.outputStream.delegate = nil;
+                [channel.inputStream removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+                [channel.outputStream removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+                // Keep the CBL2CAPChannel alive as a zombie — releasing it while the
+                // BLE connection is up would cascade-close the peripheral's channels.
+                [self.channels removeObject:channelInfo];
+                [self.zombieChannels addObject:channelInfo];
+                void(^pendingBlock)(NSError *) = self.pendingStreamReady[readyKey];
+                if (pendingBlock) {
+                    [self.pendingStreamReady removeObjectForKey:readyKey];
+                    pendingBlock([NSError errorWithDomain:@"flutter_blue_max"
+                                                     code:-1
+                                                 userInfo:@{NSLocalizedDescriptionKey: @"L2CAP channel is no longer open"}]);
+                }
+                return;
+            }
+
             // The output stream may already have space available. Since we just
             // re-attached to the run loop, HasSpaceAvailable might not fire again.
             // Check immediately and fire any pending callback.
             if (channel.outputStream.hasSpaceAvailable) {
-                NSString *readyKey = [NSString stringWithFormat:@"%@:%@", channelInfo.remoteId, channelInfo.psm];
-                void(^pendingBlock)(void) = self.pendingStreamReady[readyKey];
+                void(^pendingBlock)(NSError *) = self.pendingStreamReady[readyKey];
                 if (pendingBlock) {
                     [self.pendingStreamReady removeObjectForKey:readyKey];
-                    pendingBlock();
+                    pendingBlock(nil);
                 }
             }
         });
@@ -2890,18 +2932,21 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         case NSStreamEventHasSpaceAvailable:
             if (aStream == channelInfo.channel.outputStream) {
                 NSString *readyKey = [NSString stringWithFormat:@"%@:%@", channelInfo.remoteId, channelInfo.psm];
-                void(^pendingBlock)(void) = self.pendingStreamReady[readyKey];
+                void(^pendingBlock)(NSError *) = self.pendingStreamReady[readyKey];
                 if (pendingBlock) {
                     [self.pendingStreamReady removeObjectForKey:readyKey];
-                    pendingBlock();
+                    pendingBlock(nil);
                 }
             }
             break;
         case NSStreamEventErrorOccurred:
             NSLog(@"L2CAP Stream error: %@", [aStream streamError]);
+            // A stream error kills the channel — tear it down like a stream end,
+            // so pending opens fail and Dart gets the closed event instead of hanging.
+            [self handleStreamEndForChannel:channelInfo error:[aStream streamError]];
             break;
         case NSStreamEventEndEncountered:
-            [self handleStreamEndForChannel:channelInfo];
+            [self handleStreamEndForChannel:channelInfo error:nil];
             break;
         default:
             break;
@@ -2927,7 +2972,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     }
 }
 
-- (void)handleStreamEndForChannel:(L2CapChannelInfo *)channelInfo
+- (void)handleStreamEndForChannel:(L2CapChannelInfo *)channelInfo error:(NSError *)error
 {
     BOOL stillTracked = [self.channels containsObject:channelInfo];
     if (!stillTracked) {
@@ -2935,17 +2980,14 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     }
 
     // If there's a pending stream-ready callback (channel died before becoming writable),
-    // clean it up so the Dart side gets the close event instead of hanging.
+    // fail it so the Dart side gets an error instead of hanging.
     NSString *readyKey = [NSString stringWithFormat:@"%@:%@", channelInfo.remoteId, channelInfo.psm];
-    void(^pendingBlock)(void) = self.pendingStreamReady[readyKey];
+    void(^pendingBlock)(NSError *) = self.pendingStreamReady[readyKey];
     if (pendingBlock) {
         [self.pendingStreamReady removeObjectForKey:readyKey];
-        // Complete the pending open with an error so Dart doesn't hang
-        [self completePendingOpenForRemoteId:channelInfo.remoteId
-                                         psm:[channelInfo.psm unsignedShortValue]
-                                       error:[NSError errorWithDomain:@"flutter_blue_max"
-                                                                 code:-1
-                                                             userInfo:@{NSLocalizedDescriptionKey: @"L2CAP stream ended before becoming ready"}]];
+        pendingBlock(error ?: [NSError errorWithDomain:@"flutter_blue_max"
+                                                  code:-1
+                                              userInfo:@{NSLocalizedDescriptionKey: @"L2CAP stream ended before becoming ready"}]);
     }
 
     [self.methodChannel invokeMethod:@"OnL2CapChannelClosed" arguments:@{
@@ -2999,14 +3041,34 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     }
     [self.zombieChannels removeObjectsInArray:toRemove];
 
-    // Remove any pending stream-ready callbacks for this peripheral
-    NSMutableArray *keysToRemove = [NSMutableArray array];
-    for (NSString *key in self.pendingStreamReady) {
-        if ([key hasPrefix:remoteId]) {
-            [keysToRemove addObject:key];
+    // Fail any pending stream-ready callbacks for this peripheral. Just removing
+    // them would leave the Dart open future hanging forever (and with it the
+    // package-global mutexes, blocking all further BLE calls).
+    NSError *disconnectError = [NSError errorWithDomain:@"flutter_blue_max"
+                                                   code:-1
+                                               userInfo:@{NSLocalizedDescriptionKey: @"device disconnected before L2CAP channel became ready"}];
+    NSString *readyPrefix = [NSString stringWithFormat:@"%@:", remoteId];
+    for (NSString *key in self.pendingStreamReady.allKeys) {
+        if ([key hasPrefix:readyPrefix]) {
+            void(^pendingBlock)(NSError *) = self.pendingStreamReady[key];
+            [self.pendingStreamReady removeObjectForKey:key];
+            pendingBlock(disconnectError);
         }
     }
-    [self.pendingStreamReady removeObjectsForKeys:keysToRemove];
+
+    // Fail pending open results whose didOpenL2CAPChannel callback will never
+    // arrive (open was requested but the device disconnected first).
+    NSString *pendingOpenPrefix = [NSString stringWithFormat:@"%@: ", remoteId];
+    for (NSString *key in self.pendingOpenResults.allKeys) {
+        if ([key hasPrefix:pendingOpenPrefix]) {
+            FlutterResult pending = self.pendingOpenResults[key];
+            [self.pendingOpenResults removeObjectForKey:key];
+            pending([FlutterError errorWithCode:@"openL2CapChannel"
+                                        message:@"device disconnected before L2CAP channel opened"
+                                        details:nil]);
+        }
+    }
+    [self.pendingOpenRequestedPsm removeObjectForKey:remoteId];
 }
 
 @end

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -2533,6 +2533,59 @@ static const NSUInteger kL2CapDrainBudgetPerPass = 64 * 1024;
             return;
         }
 
+        // A previous open for this remoteId+PSM may have been abandoned by the
+        // Dart side (open timeout) while the OS-level open was still in flight.
+        // Calling openL2CAPChannel: again would fail with "L2CAP PSM already
+        // connected" once that open completes — unrecoverable without a GATT
+        // disconnect. Attach this call to the in-flight open instead.
+        NSString *pendingKey = [NSString stringWithFormat:@"%@: %@", remoteId, psmValue];
+        if (self.pendingOpenResults[pendingKey]) {
+            NSLog(@"Open already in flight for PSM %@ — attaching to pending open", psmValue);
+            self.pendingOpenResults[pendingKey] = [result copy];
+            self.pendingOpenRequestedPsm[remoteId] = psmValue;
+            return;
+        }
+
+        // If the abandoned open already completed, the channel sits in
+        // self.channels with nobody on the Dart side owning it. Adopt it
+        // instead of opening a new one (which iOS would reject).
+        L2CapChannelInfo *orphan = [self findChannelByRemoteId:remoteId psm:psmValue];
+        if (orphan && orphan.channel) {
+            NSStreamStatus orphanInStatus = orphan.channel.inputStream.streamStatus;
+            NSStreamStatus orphanOutStatus = orphan.channel.outputStream.streamStatus;
+            BOOL orphanDead = orphanInStatus == NSStreamStatusAtEnd || orphanInStatus == NSStreamStatusClosed || orphanInStatus == NSStreamStatusError
+                           || orphanOutStatus == NSStreamStatusAtEnd || orphanOutStatus == NSStreamStatusClosed || orphanOutStatus == NSStreamStatusError;
+            if (!orphanDead) {
+                NSLog(@"Adopting already-open L2CAP channel for PSM %@", psmValue);
+                // Drop bytes received while nobody owned the channel so the new
+                // owner doesn't read another session's data.
+                [orphan.readBuffer setLength:0];
+                [self.methodChannel invokeMethod:@"OnL2CapChannelOpened" arguments:@{
+                    @"remote_id": remoteId,
+                    @"psm": psmValue
+                }];
+                result(nil);
+                return;
+            }
+            // The orphaned channel died before anyone re-claimed it. Zombify it
+            // (same as handleStreamEndForChannel) and fall through to a fresh
+            // OS-level open below.
+            NSInputStream *orphanIn = orphan.channel.inputStream;
+            NSOutputStream *orphanOut = orphan.channel.outputStream;
+            orphanIn.delegate = nil;
+            orphanOut.delegate = nil;
+            [orphanIn removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+            [orphanOut removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+            [self failPendingWritesForChannel:orphan
+                                        error:[FlutterError errorWithCode:@"writeL2CapChannel"
+                                                                  message:@"L2CAP channel closed"
+                                                                  details:nil]];
+            [self.channels removeObject:orphan];
+            if (![self.zombieChannels containsObject:orphan]) {
+                [self.zombieChannels addObject:orphan];
+            }
+        }
+
         // Check if a zombie channel exists for this remoteId+PSM.
         // If so, recycle it instead of opening a new one (iOS won't allow
         // opening a PSM that's still alive, even if logically closed).
@@ -2587,8 +2640,7 @@ static const NSUInteger kL2CapDrainBudgetPerPass = 64 * 1024;
         }
 
         // Defer the result until didOpenL2CAPChannel returns (success or error)
-        NSString *key = [NSString stringWithFormat:@"%@: %@", remoteId, psmValue];
-        self.pendingOpenResults[key] = [result copy];
+        self.pendingOpenResults[pendingKey] = [result copy];
         self.pendingOpenRequestedPsm[remoteId] = psmValue;
         [peripheral openL2CAPChannel:[psmValue unsignedShortValue]];
     } else {

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -2911,7 +2911,15 @@ static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
     
     // Add to channels array
     [self.channels addObject:channelInfo];
-    
+
+    // Tell Dart a client connected to the L2CAP server. CoreBluetooth does not
+    // expose which central opened the channel, so server-accepted channels are
+    // addressed with the placeholder remoteId "server".
+    [self.methodChannel invokeMethod:@"OnL2CapChannelConnected" arguments:@{
+        @"remote_id": serverRemoteId,
+        @"psm": @(psm)
+    }];
+
     NSLog(@"L2CAP server channel ready for PSM: %d", (int)psm);
 }
 

--- a/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
+++ b/packages/flutter_blue_max_darwin/darwin/flutter_blue_max_darwin/Sources/flutter_blue_max_darwin/FlutterBlueMaxPlugin.m
@@ -2537,6 +2537,18 @@ static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
                 break;
             }
         }
+        // Only recycle a zombie whose streams are still usable. A zombie whose
+        // channel died (e.g. the peer closed it) stays in the list so it isn't
+        // dealloc'd, but the open proceeds with a fresh OS-level channel below.
+        if (zombie && zombie.channel) {
+            NSStreamStatus inStatus = zombie.channel.inputStream.streamStatus;
+            NSStreamStatus outStatus = zombie.channel.outputStream.streamStatus;
+            BOOL streamDead = inStatus == NSStreamStatusAtEnd || inStatus == NSStreamStatusClosed || inStatus == NSStreamStatusError
+                           || outStatus == NSStreamStatusAtEnd || outStatus == NSStreamStatusClosed || outStatus == NSStreamStatusError;
+            if (streamDead) {
+                zombie = nil;
+            }
+        }
         if (zombie && zombie.channel) {
             [self.zombieChannels removeObject:zombie];
             // Drop data buffered before the channel was closed so the recycled
@@ -2767,7 +2779,16 @@ static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
     if (@available(iOS 11.0, *)) {
         NSDictionary *args = call.arguments;
         NSNumber *secure = args[@"secure"];
-        
+
+        // A second concurrent listen would overwrite the first pending result,
+        // leaving its Dart future hanging forever.
+        if (self.pendingListenResult) {
+            result([FlutterError errorWithCode:@"listenL2capChannel"
+                                       message:@"another listenL2capChannel call is already in progress"
+                                       details:nil]);
+            return;
+        }
+
         // Store the result callback and settings to be used when peripheral manager is ready
         self.pendingListenResult = result;
         self.pendingListenSecure = [secure boolValue];
@@ -3102,7 +3123,14 @@ static const NSUInteger kL2CapReadBufferCap = 64 * 1024;
             [is removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
             [os removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
         }
+        // Zombify instead of releasing: dealloc'ing a CBL2CAPChannel while the
+        // BLE connection is still up makes iOS tear down ALL other L2CAP
+        // channels on the same peripheral (see zombieChannels). The zombie is
+        // released by cleanupChannelsForPeripheral once the device disconnects.
         [self.channels removeObject:channelInfo];
+        if (![self.zombieChannels containsObject:channelInfo]) {
+            [self.zombieChannels addObject:channelInfo];
+        }
     });
 }
 

--- a/packages/flutter_blue_max_darwin/lib/flutter_blue_max_darwin.dart
+++ b/packages/flutter_blue_max_darwin/lib/flutter_blue_max_darwin.dart
@@ -27,6 +27,7 @@ final class FlutterBlueMaxDarwin extends FlutterBlueMaxPlatform {
   final _onServicesResetController = StreamController<BmBluetoothDevice>.broadcast();
   final _onL2CapChannelReceivedController = StreamController<L2CapChannelData>.broadcast();
   final _onL2CapChannelClosedController = StreamController<L2CapChannelClosed>.broadcast();
+  final _onL2CapChannelConnectedController = StreamController<L2CapChannelConnected>.broadcast();
 
   @override
   Stream<BmBluetoothAdapterState> get onAdapterStateChanged {
@@ -96,6 +97,11 @@ final class FlutterBlueMaxDarwin extends FlutterBlueMaxPlatform {
   @override
   Stream<L2CapChannelClosed> get onL2CapChannelClosed {
     return _onL2CapChannelClosedController.stream;
+  }
+
+  @override
+  Stream<L2CapChannelConnected> get onL2CapChannelConnected {
+    return _onL2CapChannelConnectedController.stream;
   }
 
   static void registerWith() {
@@ -489,6 +495,12 @@ final class FlutterBlueMaxDarwin extends FlutterBlueMaxPlatform {
       case 'OnL2CapChannelClosed':
         return _onL2CapChannelClosedController.add(
           L2CapChannelClosed.fromMap(
+            call.arguments,
+          ),
+        );
+      case 'OnL2CapChannelConnected':
+        return _onL2CapChannelConnectedController.add(
+          L2CapChannelConnected.fromMap(
             call.arguments,
           ),
         );

--- a/packages/flutter_blue_max_darwin/lib/flutter_blue_max_darwin.dart
+++ b/packages/flutter_blue_max_darwin/lib/flutter_blue_max_darwin.dart
@@ -302,7 +302,7 @@ final class FlutterBlueMaxDarwin extends FlutterBlueMaxPlatform {
   Future<int> listenL2CapChannel(
     ListenL2CapChannelRequest request,
   ) async {
-    var result = await _invokeMethod('listenL2capChannel', request.toMap());
+    var result = await _invokeMethod('listenL2CapChannel', request.toMap());
     return result is Map ? (result['psm'] as int? ?? 4097) : 4097;
   }
 

--- a/packages/flutter_blue_max_darwin/lib/flutter_blue_max_darwin.dart
+++ b/packages/flutter_blue_max_darwin/lib/flutter_blue_max_darwin.dart
@@ -26,6 +26,7 @@ final class FlutterBlueMaxDarwin extends FlutterBlueMaxPlatform {
   final _onScanResponseController = StreamController<BmScanResponse>.broadcast();
   final _onServicesResetController = StreamController<BmBluetoothDevice>.broadcast();
   final _onL2CapChannelReceivedController = StreamController<L2CapChannelData>.broadcast();
+  final _onL2CapChannelClosedController = StreamController<L2CapChannelClosed>.broadcast();
 
   @override
   Stream<BmBluetoothAdapterState> get onAdapterStateChanged {
@@ -90,6 +91,11 @@ final class FlutterBlueMaxDarwin extends FlutterBlueMaxPlatform {
   @override
   Stream<L2CapChannelData> get onL2CapChannelReceived {
     return _onL2CapChannelReceivedController.stream;
+  }
+
+  @override
+  Stream<L2CapChannelClosed> get onL2CapChannelClosed {
+    return _onL2CapChannelClosedController.stream;
   }
 
   static void registerWith() {
@@ -477,6 +483,12 @@ final class FlutterBlueMaxDarwin extends FlutterBlueMaxPlatform {
       case 'OnL2CapChannelReceived':
         return _onL2CapChannelReceivedController.add(
           L2CapChannelData.fromMap(
+            call.arguments,
+          ),
+        );
+      case 'OnL2CapChannelClosed':
+        return _onL2CapChannelClosedController.add(
+          L2CapChannelClosed.fromMap(
             call.arguments,
           ),
         );

--- a/packages/flutter_blue_max_platform_interface/lib/flutter_blue_max_platform_interface.dart
+++ b/packages/flutter_blue_max_platform_interface/lib/flutter_blue_max_platform_interface.dart
@@ -87,6 +87,10 @@ abstract base class FlutterBlueMaxPlatform {
     return Stream.empty();
   }
 
+  Stream<L2CapChannelClosed> get onL2CapChannelClosed {
+    return Stream.empty();
+  }
+
   Stream<BmBluetoothDevice> get onServicesReset {
     return Stream.empty();
   }

--- a/packages/flutter_blue_max_platform_interface/lib/flutter_blue_max_platform_interface.dart
+++ b/packages/flutter_blue_max_platform_interface/lib/flutter_blue_max_platform_interface.dart
@@ -91,6 +91,10 @@ abstract base class FlutterBlueMaxPlatform {
     return Stream.empty();
   }
 
+  Stream<L2CapChannelConnected> get onL2CapChannelConnected {
+    return Stream.empty();
+  }
+
   Stream<BmBluetoothDevice> get onServicesReset {
     return Stream.empty();
   }

--- a/packages/flutter_blue_max_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_max_platform_interface/lib/src/bluetooth_msgs.dart
@@ -1255,6 +1255,27 @@ class L2CapChannelData {
   }
 }
 
+/// Event emitted when an L2CAP channel is closed by the remote device,
+/// a stream error, or a device disconnect.
+class L2CapChannelClosed {
+  /// The device identifier of the remote device
+  final DeviceIdentifier remoteId;
+
+  /// The PSM (Protocol Service Multiplexer) of the channel that was closed
+  final int psm;
+
+  /// Creates a new [L2CapChannelClosed] instance
+  L2CapChannelClosed({required this.remoteId, required this.psm});
+
+  /// Creates an [L2CapChannelClosed] from a platform message map
+  factory L2CapChannelClosed.fromMap(Map<dynamic, dynamic> map) {
+    return L2CapChannelClosed(
+      remoteId: DeviceIdentifier(map['remote_id']),
+      psm: map['psm'],
+    );
+  }
+}
+
 // random number defined by flutter blue plus.
 // Ideally it should not conflict with iOS or Android error codes.
 int bmUserCanceledErrorCode = 23789258;

--- a/packages/flutter_blue_max_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_max_platform_interface/lib/src/bluetooth_msgs.dart
@@ -1276,6 +1276,32 @@ class L2CapChannelClosed {
   }
 }
 
+/// Event emitted when a remote device connects to an L2CAP server
+/// started with `listenL2capChannel`.
+class L2CapChannelConnected {
+  /// The identifier to address the accepted channel with.
+  ///
+  /// On Android this is the connecting client's MAC address. On iOS
+  /// CoreBluetooth does not expose which central opened the channel, so the
+  /// placeholder id `server` is reported instead — both platforms accept it
+  /// for channel operations on server-accepted channels.
+  final DeviceIdentifier remoteId;
+
+  /// The PSM (Protocol Service Multiplexer) of the server that was connected to
+  final int psm;
+
+  /// Creates a new [L2CapChannelConnected] instance
+  L2CapChannelConnected({required this.remoteId, required this.psm});
+
+  /// Creates an [L2CapChannelConnected] from a platform message map
+  factory L2CapChannelConnected.fromMap(Map<dynamic, dynamic> map) {
+    return L2CapChannelConnected(
+      remoteId: DeviceIdentifier(map['remote_id']),
+      psm: map['psm'],
+    );
+  }
+}
+
 // random number defined by flutter blue plus.
 // Ideally it should not conflict with iOS or Android error codes.
 int bmUserCanceledErrorCode = 23789258;

--- a/packages/flutter_blue_max_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_max_platform_interface/lib/src/bluetooth_msgs.dart
@@ -1016,24 +1016,6 @@ class PhySupport {
   }
 }
 
-/// Represents an L2CAP channel connection event.
-///
-/// This class is used internally to handle L2CAP channel connection events
-/// from the platform layer. It contains information about which device
-/// connected and on which PSM.
-class L2CapChannelConnected {
-  /// The device identifier of the remote device that connected
-  final DeviceIdentifier remoteId;
-  
-  /// The Protocol Service Multiplexer (PSM) of the connected channel
-  final int psm;
-
-  /// Creates an [L2CapChannelConnected] from a platform message map
-  L2CapChannelConnected.fromMap(Map<dynamic, dynamic> map)
-      : remoteId = DeviceIdentifier(map['remote_id']),
-        psm = map['psm'];
-}
-
 /// Request message for starting an L2CAP server.
 ///
 /// Used internally to communicate with the platform layer when


### PR DESCRIPTION
# L2CAP stability improvements

Fixes a series of crashes, hangs, and data-corruption bugs in the L2CAP implementation on Android and iOS, and adds channel close events plus timeouts to the public API.

## What was fixed

| Platform | Problem | Fix |
|---|---|---|
| Both | `listenL2capChannel` always threw `MissingPluginException` — Dart called `listenL2CapChannel`, native handlers registered `listenL2capChannel` | Wire method renamed to `listenL2CapChannel` across all layers |
| Android | `BluetoothSocket.connect()`/`write()` ran on the main thread — UI freezes/ANRs and stalled GATT callbacks for **all** devices while blocked | Blocking socket I/O moved to a per-channel background executor; results posted back to the main thread |
| Android | Reader loop only caught `IOException` — any other exception (e.g. NPE from a concurrent `close()`) killed the app process; reconnects could spawn duplicate reader threads | Loop snapshots socket/stream, catches all exceptions; a generation counter ensures only one reader per channel |
| Android | Fixed 512-byte read buffer silently truncated larger SDUs (L2CAP CoC discards the rest of the packet); `read()` returned the shared untrimmed buffer | Buffers sized from the socket MTU; fresh trimmed copy per read |
| Android | Channel lookups keyed by PSM only — two devices sharing a PSM (common with fixed firmware PSMs) got each other's channels: NPEs, `ClassCastException`s, closing the wrong device's channel | Lookups keyed by device + PSM |
| Android | Server accept loop busy-spun forever after an `IOException` (dead server socket); channel-list iteration raced the accept thread; double `Result` reply crashed with "Reply already submitted" | Accept loop stops on error; list access synchronized; single reply per call |
| iOS | `openL2CapChannel` hung forever (holding the package-wide mutexes) if the channel died before becoming ready — stream error, disconnect, or dead zombie recycle | Every failure path now fails the pending open with an error; disconnect also fails pending opens/writes |
| iOS | `NSOutputStream` partial writes silently dropped bytes; writes under backpressure failed with "Output stream not ready" | Writes are queued per channel and drained on `HasSpaceAvailable`; the Dart future completes only when all bytes are accepted |
| iOS | Per-channel poll buffer grew without bound if the app only consumed the event stream — eventual OOM kill | Buffer capped at 64 KiB (drop-oldest) |
| iOS | Recycled (zombie) channels started with the previous session's stale data; dead zombies were recycled and hung the open | Stale buffers/socket data drained on recycle; dead zombies are not reused |
| iOS | Stream errors were only logged — the channel stayed half-alive; closing a channel could release the `CBL2CAPChannel` and cascade-close all channels on the peripheral | Stream errors tear the channel down like a stream end; channels are consistently zombified until disconnect |
| iOS | A second concurrent `listenL2capChannel` overwrote the first pending result, hanging its Dart future | Concurrent listen now returns an error |
| Dart | A platform call that never completed held the package-wide operation mutexes forever, blocking all further Bluetooth calls | `openL2CapChannel` and `listenL2capChannel` now time out (configurable, defaults 35 s / 15 s) |
| Both | An L2CAP server was unusable from Dart: the native "client connected" events were silently dropped (no Dart handler), and Android rejected the `server` placeholder id that iOS requires — server-side read/write crashed with `IllegalArgumentException` | New `OnL2CapChannelConnected` event wired through both platforms; Android now also accepts `server` for operations on server-accepted channels |

## New API

- `BluetoothL2capChannel.onClosed` — per-channel stream that fires when the channel dies (remote close, stream error, or disconnect). Previously the only way to notice was a failing read/write.
- `FlutterBlueMax.onL2capClosed` — global close-event stream, also covers server-side channels.
- `FlutterBlueMax.onL2capConnected` — fires when a remote device connects to a server started with `listenL2capChannel`. The event's remoteId addresses the accepted channel: the client's MAC on Android, the placeholder `server` on iOS (CoreBluetooth doesn't expose the connecting central).
- `timeout` parameters on `openL2CapChannel` and `listenL2capChannel`.

## Recommendations for existing apps

The crash and data-corruption fixes apply automatically on upgrade — reader-loop crashes, ANRs, truncated SDUs, wrong-channel lookups, and dropped iOS writes are gone without code changes. A few things are worth adopting, especially where apps built workarounds:

- **Handle open/listen failures instead of hangs.** `openL2CapChannel` / `listenL2capChannel` could previously hang forever and freeze all Bluetooth calls (often "fixed" by restarting the app). They now throw — after 35 s / 15 s at the latest, configurable via `timeout` — so wrap them in try/catch and retry as appropriate.
- **Subscribe to `channel.onClosed` (or `FlutterBlueMax.onL2capClosed`).** If an app detects dead channels by a failing `write()` — or waits forever on data that will never arrive — the close event now reports the death immediately, so the channel can be torn down or reopened.
- **Server apps: use `FlutterBlueMax.onL2capConnected`.** This is the first version where an L2CAP server is fully usable: `listenL2capChannel` no longer throws `MissingPluginException`, and the connected event provides the channel handle for writing back to the client (previously impossible on Android).
- **Remove write-pacing workarounds on iOS.** Writes used to drop bytes silently under backpressure; if delays between writes were added to compensate, `await channel.write(...)` now completes only once every byte has been accepted.
- **Remove ≤512-byte payload chunking for Android receivers.** Incoming SDUs were silently truncated to 512 bytes; read buffers are now MTU-sized, so payloads up to the negotiated MTU arrive intact.
- **Multiple devices sharing a PSM now work concurrently.** If connections to same-product devices (fixed firmware PSM) were serialized to avoid crashes or cross-talk, that's no longer necessary — channels are keyed by device + PSM.

## Example app

The L2CAP section of the example was reworked so the above is actually testable:

- Server mode tracks accepted clients via `onL2capConnected` and targets them for send/read — previously it used a placeholder that crashed on Android — and shows the connected client.
- Channels disappear from the UI on `onL2capClosed` instead of lingering until a failed write.
- New test-traffic buttons: a 10 KB patterned payload (exercises SDU/MTU handling) and a 20×1 KB write burst (exercises write queueing/backpressure), plus a received-bytes counter to verify nothing was lost.
- Received data renders as text or a hex preview, sends are UTF-8, and incoming data is matched by device + PSM instead of PSM alone.

## Notes

- The `listenL2capChannel` → `listenL2CapChannel` wire rename is internal; Dart and native sides are updated together in this PR.
- Native error details now pass `e.toString()` instead of the exception object, which is not codec-encodable and crashed the error path itself.
